### PR TITLE
Removing copy and link around "alpha" version of the Standards.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -5,10 +5,6 @@
       <img src="{{ site.baseurl }}/assets/img/favicons/favicon-40.png" alt="U.S. flag">
       <p>An official website of the United States government</p>
     </div>
-    <p class="usa-disclaimer-stage">
-      This site is currently in alpha.
-      <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a>
-    </p>
   </div>
   <div class="usa-navbar site-header-navbar">
     <button class="usa-menu-btn">Menu</button>


### PR DESCRIPTION
We are removing the link "alpha" definition around the project, as the link no longer works and the context is there unclear.

Fixes #1 