### PR TITLE
Updating _config.yml to point to the correct version of the Standards.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 name: Draft U.S. Web Design Standards Documentation
-version: 0.10.0
+version: 0.12.1
 permalink: pretty
 google_analytics_ua: UA-48605964-43
 
@@ -50,3 +50,5 @@ exclude:
 - node_modules
 - package.json
 - vendor
+- gulpfile.js
+- circle.yml


### PR DESCRIPTION
This also excludes the `gulpfile.js` and the `circle.yml` from the build step.