### PR TITLE
Add watch command to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Here are a few other utility commands you may find useful:
 
 - `npm test`: Runs `npm run lint` and can also be used to run any tests.
 
+- `npm run watch`: Runs a series of commands that watches for any changes in both the Standards node module and the root level asset folders in this repo.
+
 ### Using the latest version of the `uswds` package
 
 Sometimes you will want to use the latest version of the `web-design-standards` repo. Follow these steps to do so:
@@ -60,10 +62,10 @@ Sometimes you will want to use the latest version of the `web-design-standards` 
 1. Run `npm build:package` to create the built version of the Standards.
 1. Run `npm link` in the _root level_ of the `web-design-standards` directory on your local machine.
 1. Run `npm link uswds` in the _root level_ of the `web-design-standards-docs` directory on your local machine.
+1. Run `npm run watch` in both projects to have changes automatically built and compiled on changes to any asset files.
+1. In a new terminal window, run `npm start` to start the Jekyll server locally.
 
 You are now using the latest version of the Standards via your cloned version on your local machine. To stop using this version, type `npm unlink uswds` from the _root level_ of the `web-design-standards-docs` directory.
-
-**NOTE: Remember, you will want to be “watching” the `uswds` package if you plan on making updates to that package.**
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "gulp eslint scss-lint",
     "prestart": "bundle && gulp build",
     "start": "bundle exec jekyll serve",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "watch": "onchange './node_modules/uswds/src' './css/**/*.scss' './img' './js/**/*.js' -v -- npm run build"
   },
   "repository": {
     "type": "git",
@@ -46,6 +47,7 @@
     "merge-stream": "^1.0.0",
     "node-notifier": "^4.6.0",
     "normalize.css": "^3.0.3",
+    "onchange": "git+https://git@github.com/msecret/onchange.git",
     "politespace": "^0.1.4",
     "prismjs": "^1.5.1",
     "run-sequence": "^1.1.5",


### PR DESCRIPTION
This pull request adds in a `watch` command to the `package.json` file. This enables users to be able to use this command to automatically build and compile assets from the `web-design-standards` node module, as well as the specific assets for the docs/website itself.