### PR TITLE
Fix assets download button link.

### DIFF
--- a/_includes/download-buttons-design.html
+++ b/_includes/download-buttons-design.html
@@ -3,8 +3,8 @@ These `uswds-assets-*.zip` files are generated in 18F/web-design-standards-asset
 repository. See: https://github.com/18F/web-design-standards-assets
 {% endcomment %}
 <div class="link_group-download">
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-ai.zip" onclick="ga('send', 'event', 'Downloaded design files - Illustrator', 'Clicked download design files button inside site');">Download design files (Illustrator)</a>
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-sketch.zip" onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download design files (Sketch)</a>
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-eps.zip" onclick="ga('send', 'event', 'Downloaded design files - EPS', 'Clicked download design files button inside site');">Download design files (EPS)</a>
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-ai.zip" onclick="ga('send', 'event', 'Downloaded design files - Illustrator', 'Clicked download design files button inside site');">Download design files (Illustrator)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-sketch.zip" onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download design files (Sketch)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-eps.zip" onclick="ga('send', 'event', 'Downloaded design files - EPS', 'Clicked download design files button inside site');">Download design files (EPS)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>
 </div>


### PR DESCRIPTION
The button for downloading the visual design assets are currently not downloading from the correct path. This pull request fixes this error.