### PR TITLE
Update css watch cmd to point to the correct styles dir for uswds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "./css/**/*.scss": ["build-css"],
     "./img": ["build-img"],
     "./js/**/*.js": ["build-js"],
-    "./node_modules/uswds/src/css": ["build-css"],
+    "./node_modules/uswds/src/stylesheets": ["build-css"],
     "./node_modules/uswds/src/fonts": ["build-fonts"],
     "./node_modules/uswds/src/html": ["build-html"],
     "./node_modules/uswds/src/img": ["build-img"],


### PR DESCRIPTION
The `watch` command currently points to the incorrect directory for the WDS packaged styles, which therefore does not update the styles correctly when developing locally. This PR solves the crime!