### PR TITLE
Clean up npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ To start, run the following command to install project dependencies:
 npm install
 ```
 
-Next, you’ll perform a build step to copy and compile all of the necessary files that create the site:
-
-```sh
-npm run build
-```
-
 Now that all of your dependencies are installed, you can run your local server by running the following command:
 
 ```sh

--- a/_includes/download-buttons-design.html
+++ b/_includes/download-buttons-design.html
@@ -3,8 +3,8 @@ These `uswds-assets-*.zip` files are generated in 18F/web-design-standards-asset
 repository. See: https://github.com/18F/web-design-standards-assets
 {% endcomment %}
 <div class="link_group-download">
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-ai.zip" onclick="ga('send', 'event', 'Downloaded design files - Illustrator', 'Clicked download design files button inside site');">Download design files (Illustrator)</a>
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-sketch.zip" onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download design files (Sketch)</a>
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-eps.zip" onclick="ga('send', 'event', 'Downloaded design files - EPS', 'Clicked download design files button inside site');">Download design files (EPS)</a>
-  <a class="link-download" href="{{ site.baseurl }}/assets/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-ai.zip" onclick="ga('send', 'event', 'Downloaded design files - Illustrator', 'Clicked download design files button inside site');">Download design files (Illustrator)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-sketch.zip" onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download design files (Sketch)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-eps.zip" onclick="ga('send', 'event', 'Downloaded design files - EPS', 'Clicked download design files button inside site');">Download design files (EPS)</a>
+  <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>
 </div>

--- a/circle.yml
+++ b/circle.yml
@@ -22,8 +22,7 @@ test:
     - scss-lint -v
     - jekyll -v
   override:
-    - gulp build # Build site files
-    - bundle exec jekyll build # Build Jekyll website
+    - npm run build # Build site files
     - npm test # Run the package and test suite
   post:
     - ls -agolf _site/ # Ensure that build worked

--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -25,6 +25,10 @@ gulp.task('remove-assets-folder', function () {
   return del('assets/');
 });
 
+gulp.task('remove-components-folder', function () {
+  return del('_includes/code/components');
+});
+
 gulp.task('clean-assets', function (done) {
   runSequence(
     [
@@ -33,6 +37,7 @@ gulp.task('clean-assets', function (done) {
       'clean-javascript',
       'clean-styles',
       'remove-assets-folder',
+      'remove-components-folder',
     ],
     done
   );
@@ -48,11 +53,11 @@ gulp.task('build', function (done) {
   runSequence(
     'clean-assets',
     [
-    'fonts',
-    'images',
-    'javascript',
-    'sass',
-    'html',
+      'fonts',
+      'images',
+      'javascript',
+      'sass',
+      'html',
     ],
     done
   );

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -1,7 +1,7 @@
 var gulp      = require('gulp');
 var dutil     = require('./doc-util');
 var linter    = require('gulp-scss-lint');
-var task      = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var runSequence   = require('run-sequence');
 
 gulp.task('copy-doc-styles', function (done) {
 
@@ -41,8 +41,17 @@ gulp.task('scss-lint', function (done) {
 
 });
 
-gulp.task(task, [ 'copy-doc-styles', 'copy-uswds-styles', 'scss-lint' ], function (done) {
+gulp.task('sass', function (done) {
 
-  dutil.logMessage(task, 'Compiling Sass');
+  dutil.logMessage('sass', 'Compiling Sass');
+
+  runSequence(
+    [
+      'copy-doc-styles',
+      'copy-uswds-styles',
+      'scss-lint'
+    ],
+    done
+  );
 
 });

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -8,7 +8,7 @@ gulp.task('copy-doc-styles', function (done) {
   dutil.logMessage('copy-doc-styles', 'Copying Sass files from css/');
 
   var stream = gulp.src('./css/**/*')
-  .pipe(gulp.dest('assets/css/'));
+    .pipe(gulp.dest('assets/css/'));
 
   return stream;
 
@@ -19,7 +19,7 @@ gulp.task('copy-uswds-styles', function (done) {
   dutil.logMessage('copy-uswds-styles', 'Copying Sass files from uswds');
 
   var stream = gulp.src('./node_modules/uswds/src/stylesheets/**/*')
-  .pipe(gulp.dest('assets/css/vendor/uswds'));
+    .pipe(gulp.dest('assets/css/vendor/uswds'));
 
   return stream;
 

--- a/js/components/calculate-anchor-position.js
+++ b/js/components/calculate-anchor-position.js
@@ -15,7 +15,7 @@ var calculateAnchorPosition = function (hash) {
   var anchorPadding = parseInt(anchor.css('padding-top'), 10);
 
   //start with the height of the header
-  var topOffset = $('.site-nav-secondary').first().outerHeight();
+  topOffset = $('.site-nav-secondary').first().outerHeight();
   //subtract the diffence in padding between nav top and anchor
   topOffset = topOffset - (anchorPadding - navPadding);
 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Website and documentation on using the Draft U.S. Web Design Standards.",
   
   "scripts": {
-    "build": "bundle && gulp build && bundle exec jekyll build",
-    "build-css": "gulp sass && bundle exec jekyll build",
-    "build-js": "gulp javascript && bundle exec jekyll build",
-    "build-img": "gulp images && bundle exec jekyll build",
-    "build-fonts": "gulp fonts && bundle exec jekyll build",
-    "build-html": "gulp html && bundle exec jekyll build",
+    "build": "gulp build && bundle exec jekyll build",
+    "build-css": "gulp sass",
+    "build-js": "gulp javascript",
+    "build-img": "gulp images",
+    "build-fonts": "gulp fonts",
+    "build-html": "gulp html",
     "clean": "gulp clean-assets",
     "lint": "gulp eslint scss-lint",
     "prestart": "bundle && gulp build",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build-html": "gulp html",
     "clean": "gulp clean-assets",
     "lint": "gulp eslint scss-lint",
-    "prestart": "bundle && gulp build",
+    "postinstall": "bundle",
+    "prestart": "gulp build",
     "start": "bundle exec jekyll serve",
     "test": "npm run lint",
     "watch": "nswatch"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "Marco Segreto <marco.segreto@gsa.gov>",
     "Maya Benari <maya.ben-ari@gsa.gov>",
     "Roger Steve Ruiz <roger.ruiz@gsa.gov>",
+    "Shawn Allen <shawn.allen@gsa.gov>",
     "Yoz Grahame <jeremy.grahame@gsa.gov>"
   ],
   "license": "SEE LICENSE in LICENSE.md",


### PR DESCRIPTION
This fixes #50 and tidies up a couple of the other scripts to simplify the install + build + watch process:

- [x] Remove the `&& bundle exec jekyll build` step from each of the asset-specific `build-*` scripts.
- [x] The `build` and `prestart` scripts no longer call `bundle`. Instead, `bundle` is called once in the `postinstall` hook (which is called at the end of a successful `npm install`).
- [x] Nix the `npm run build` step from the README.
- [x] Fix a linting error in a [re-declared variable](files#diff-bd172c7b464c275bb7733e999c156f55R18).