### PR TITLE
Tidy gulp tasks

### DIFF
--- a/config/gulp/doc-util.js
+++ b/config/gulp/doc-util.js
@@ -83,7 +83,7 @@ module.exports = {
     message = message || 'Draft U.S. Web Design Standards Documentation';
 
     gutil.log(
-      gutil.colors.yellow('v' + pkg.version),
+      chalk.yellow('v' + pkg.version),
       message
     );
     drawFlag();
@@ -94,8 +94,8 @@ module.exports = {
 
     gutil.log(
       shellPrefix,
-      gutil.colors.cyan(name),
-      gutil.colors.magenta(message)
+      chalk.cyan(name),
+      chalk.magenta(message)
     );
 
   },
@@ -104,8 +104,8 @@ module.exports = {
 
     gutil.log(
       shellPrefix,
-      gutil.colors.cyan(name),
-      gutil.colors.yellow(message)
+      chalk.cyan(name),
+      chalk.yellow(message)
     );
 
   },
@@ -113,8 +113,8 @@ module.exports = {
   logData: function (name, message) {
 
     gutil.log(
-      gutil.colors.cyan(name),
-      gutil.colors.yellow(message)
+      chalk.cyan(name),
+      chalk.yellow(message)
     );
 
   },
@@ -122,8 +122,8 @@ module.exports = {
   logError: function (name, message) {
 
     gutil.log(
-      gutil.colors.red(name),
-      gutil.colors.yellow(message)
+      chalk.red(name),
+      chalk.yellow(message)
     );
     notify(this.dirName + ' gulp ' + name, message, true);
 
@@ -132,8 +132,8 @@ module.exports = {
   logMessage: function (name, message) {
 
     gutil.log(
-      gutil.colors.cyan(name),
-      gutil.colors.green(message)
+      chalk.cyan(name),
+      chalk.green(message)
     );
     notify(this.dirName + ' gulp ' + name, message, false);
 

--- a/config/gulp/doc-util.js
+++ b/config/gulp/doc-util.js
@@ -1,5 +1,6 @@
 var pkg         = require('../../package.json');
 var gutil       = require('gulp-util');
+var chalk       = gutil.colors;
 var notifier    = require('node-notifier');
 
 var shellPrefix = '$';
@@ -9,50 +10,50 @@ function drawFlag () {
   // American Flag in ASCII
   //
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.blue('xxxxxxxxxxxxxxxxxxxxxxxxxxxx'),
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.white('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
   gutil.log(
-    gutil.colors.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    chalk.red('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
   );
 
 }
@@ -86,10 +87,6 @@ module.exports = {
       message
     );
     drawFlag();
-    //gutil.log(
-      //gutil.colors.yellow('v' + pkg.version),
-      //'The following gulp commands are available'
-    //);
 
   },
 

--- a/config/gulp/fonts.js
+++ b/config/gulp/fonts.js
@@ -1,6 +1,6 @@
 var gulp  = require('gulp');
 var dutil = require('./doc-util');
-var task  = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task  = 'fonts';
 
 gulp.task(task, function (done) {
 

--- a/config/gulp/images.js
+++ b/config/gulp/images.js
@@ -1,6 +1,6 @@
 var gulp  = require('gulp');
 var dutil = require('./doc-util');
-var task  = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task  = 'images';
 
 gulp.task('copy-doc-images', function (done) {
 

--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -8,7 +8,7 @@ var uglify      = require('gulp-uglify');
 var sourcemaps  = require('gulp-sourcemaps');
 var rename      = require('gulp-rename');
 var linter      = require('gulp-eslint');
-var task        = /([\w\d-_]+)\.js$/.exec(__filename)[ 1 ];
+var task        = 'javascript';
 
 gulp.task('eslint', function (done) {
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "uswds-docs",
   "version": "0.1.0",
   "description": "Website and documentation on using the Draft U.S. Web Design Standards.",
-  
   "scripts": {
     "build": "gulp build && bundle exec jekyll build",
     "build-css": "gulp sass",


### PR DESCRIPTION
- Don't infer the task name from `__filename` in fonts, images, and javascript gulp configs.
- Reference `gutil.colors` as [chalk](https://www.npmjs.com/package/chalk) in doc-utils so it's clearer which terminal color API we're using.