### PR TITLE
Update footer with new copy and links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ repos:
   url: https://github.com/18F/web-design-standards
 - name: Draft U.S. Web Design Standards Documentation
   description: Documentation for the Draft U.S. Web Design Standards
-  url: https://github.com/18F/web-design-standards
+  url: https://github.com/18F/web-design-standards-docs
 - name: Draft U.S. Web Design Standards Assets
   description: Draft U.S. Web Design Standards visual design assets
   url: https://github.com/18F/web-design-standards-assets

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,11 +12,11 @@
   </div>
   <div class="footer-text">
     <div class="footer-text-one-half">
-      <p>Feedback? Create an issue on the <a href="{{ site.repos[0].url }}">GitHub repository</a> or email us at <a href="mailto:uswebdesignstandards@gsa.gov">uswebdesignstandards@gsa.gov</a>.</p>
-      <p>Have an idea? Read our <a href="{{ site.repos[0].url }}/blob/master/CONTRIBUTING.md">contribution guidelines</a>.</p>      
-    </div>
-    <div class="footer-text-one-half">
+      <p>Feedback? Create an issue on the <a href="{{ site.repos[0].url }}">Standards component repo</a> or email us at <a href="mailto:uswebdesignstandards@gsa.gov">uswebdesignstandards@gsa.gov</a>.</p>
+      <p>Have an idea? Read our <a href="{{ site.repos[0].url }}/blob/staging/CONTRIBUTING.md">contribution guidelines</a>.</p>
+      <p><a href="{{ site.repos[1].url }}/blob/staging/{{ page.path }}">Edit this page</a></p>      
       <p>As a work of the United States government, this project is <a href="{{ site.repos[0].url }}/blob/master/LICENSE.md">in the public domain</a>.</p>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
This pull request updates the footer per the new copy outlined by @kategarklavs in #25. These updates were suggested per the repository split that happened a month ago.

It also adds in a link to easily point users to the page they are looking at to make any edits 🎉 We are also pointing to blobs instead of trees. You can read more about that here: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects

Also, I found a bug in which we failed to update the `_config.yml` to point to the correct repo url. This PR fixes that!