### PR TITLE
Add ability to deploy any branch named demo-*

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Sometimes you will want to use the latest version of the `web-design-standards` 
 
 You are now using the latest version of the Standards via your cloned version on your local machine. To stop using this version, type `npm unlink uswds` from the _root level_ of the `web-design-standards-docs` directory.
 
+### Continuously Delivered Demo Sites
+
+Submitting a PR with a branch name prefixed with `demo_` will trigger a deployment to `standards-demo-<BRANCH_NAME>.usa.gov`. Please be mindful of using these deployments sparingly. Once a branch has been deleted or abandoned, the instance in :cloud:.gov can be deleted with the following commands.
+
+```shell
+$ cf t -o gsa-wds -s wds-demo # target the proper org and space.
+$ cf apps # lists all applications in the space.
+$ cf delete -f standards-demo-<BRANCH_NAME> # to delete the application without prompting.
+```
+
+This feature is limited to pull requests not coming from forks.
+
 ## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md). These guidelines are directions for opening issues and submitting pull requests, and they also detail the coding and design standards we follow.

--- a/circle.yml
+++ b/circle.yml
@@ -44,5 +44,5 @@ deployment:
     branch: /demo_.*/
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-demo
-      - cf zero-downtime-push wds-microsite -f manifest-demo.yml -p _site
-      - cf map-route wds-microsite standards-demo.usa.gov
+      - cf push "wds-microsite-$(CIRCLE_BRANCH)" -f manifest-demo.yml -p _site
+      - cf map-route "wds-microsite-$(CIRCLE_BRANCH)" "standards-demo-$(CIRCLE_BRANCH).usa.gov"

--- a/circle.yml
+++ b/circle.yml
@@ -29,14 +29,20 @@ test:
 
 deployment:
   production:
-    branch: [master]
+    branch: master
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-production
       - cf zero-downtime-push wds-microsite -f manifest.yml -p _site
       - cf map-route wds-microsite standards.usa.gov
   staging:
-    branch: [staging]
+    branch: staging
     commands:
       - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-staging
       - cf zero-downtime-push wds-microsite -f manifest-staging.yml -p _site
       - cf map-route wds-microsite standards-staging.usa.gov
+  demo:
+    branch: /demo_.*/
+    commands:
+      - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-demo
+      - cf zero-downtime-push wds-microsite -f manifest-demo.yml -p _site
+      - cf map-route wds-microsite standards-demo.usa.gov

--- a/manifest-demo.yml
+++ b/manifest-demo.yml
@@ -1,0 +1,4 @@
+# Manifest file for automated deployments to our staging environment.
+---
+inherit: manifest.yml
+host: wds-microsite-demo


### PR DESCRIPTION
This pull request adds the ability to push any branch named `demo-[insert anything!]` to `standards-demo.cloud.gov`. The goal is to make it easy to deploy multiple branches to an instance without have to merge in.

@rogeruiz would <3 your expert cloud.gov eyes on this for a review!
