### PR TITLE
Removed the line stating jQuery 2.2.0 is included with the USWDS. jQu…

### DIFF
--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -55,10 +55,6 @@ of your downloaded assets. And the un-minified version is better if you are in a
 development environment or would like to debug the CSS or JavaScript assets in
 the browser. The examples above recommend using the minified versions.
 
-This version of the Standards includes jQuery version `2.2.0` bundled within the
-JavaScript file. Please make sure that you're not including any other version
-of jQuery on your page.
-
 And that’s it — you should be set to use the Standards.
 
 ### Using npm

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -59,6 +59,8 @@ And that’s it — you should be set to use the Standards.
 
 ### Using npm
 
+Note: Using npm to install the Standards will include jQuery version `2.2.0`. Please make sure that you're not including any other version of jQuery on your page.
+
 If you have `node` installed on your machine, you can use npm to install the Standards. Add `uswds`
 to your project's `package.json` as a dependency:
 


### PR DESCRIPTION
## [Update Developer Documentation]: Remove jQuery Note

## Description

The documentation currently suggests that uswds.js includes jQuery 2.2.0. This can cause issues and break pages if a.) there is an expectation that jQuery will be loaded to the global namespace or b.) another version of jQuery is already being loaded.

## Additional information

I am not sure what the plan is for uswds.js. There seems to be some relics of when jQuery was actually bundled. 

I would recommend not having any jQuery or reference to jQuery unless jQuery is required as a dependancy. 