### PR TITLE
Add expanded customization section with examples

### DIFF
--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -132,18 +132,18 @@ You can also email us directly at uswebdesignstandards@gsa.gov.
 
 ## Customization/theming
 
-The standards are ready to be customized to use different typography, colors and grid system. The easiest way to customize the standards is to use Sass and override the standards global variables. If it isn't possible to use Sass, theming must be done by over-riding CSS rules the standards set.
+The Standards can be customized to use different typography, colors and grid systems. The easiest way to do this is to use Sass and override the Standards' global variables. If it isn't possible to use Sass, do theming by overriding the CSS rules in the Standards set.
 
-To start theming through Sass, copy the `core/variables` file into your own project's Sass folder, changing applicable variable values, and importing it before the WDS. Below is an example of customizing the WDS.
+To start theming through Sass, copy the `core/variables` file into your own project's Sass folder, changing applicable variable values, and importing it before the WDS. Below is an example of customizing the import of the Standards all.scss file.
 
 ```scss
 // src/main.scss
-@import 'src/my-custom-vars';
+@import 'path/to/my/scss/files/main/scss/my-custom-vars';
 @import 'lib/uswds/src/stylesheets/all';
 ```
 
 ```scss
-// src/_my-custom_vars.scss
+// path/to/my/scss/files/main/scss/my-custom_vars.scss
 
 // Colors
 $color-primary: #2c3e50;
@@ -162,7 +162,7 @@ $medium-screen: 620px !default;
 $large-screen:  1120px !default;
 ```
 
-Do not every change any code in your `uswds` folder. Doing so could make it impossible to upgrade WDS in the future without undoing your changes.
+NOTE: If you plan on upgrading to newer versions of the Standards in the future, or are not using your own forked version of the Standards, try to avoid making changes in the Standards folder themselves. Doing so could make it impossible to upgrade in the future without undoing your custom changes.
 
 ### Main variables that can be customized
 * Colors can be found in the `core/variables` [file, line 35](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L35).

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -134,7 +134,7 @@ You can also email us directly at uswebdesignstandards@gsa.gov.
 
 The standards are ready to be customized to use different typography, colors and grid system. The easiest way to customize the standards is to use Sass and override the standards global variables. If it isn't possible to use Sass, theming must be done by over-riding CSS rules the standards set.
 
-To start theming through Sass, copy the `core/variables` file into your own project's Sass folder, changing applicable variable values, and importing it before the WDS.
+To start theming through Sass, copy the `core/variables` file into your own project's Sass folder, changing applicable variable values, and importing it before the WDS. Below is an example of customizing the WDS.
 
 ```scss
 // src/main.scss
@@ -164,7 +164,7 @@ $large-screen:  1120px !default;
 
 Do not every change any code in your `uswds` folder. Doing so could make it impossible to upgrade WDS in the future without undoing your changes.
 
-### Where to find customizable variables
+### Main variables that can be customized
 * Colors can be found in the `core/variables` [file, line 35](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L35).
 * Font families can be found in the `core/variables` [file, line 28](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L28).
 * Typography sizing can be found in `core/variables` [file, line 13](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L13).

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -122,12 +122,54 @@ You can also email us directly at uswebdesignstandards@gsa.gov.
 * Uses a **[modified BEM](https://pages.18f.gov/frontend/css-coding-styleguide/naming/)** approach created by 18F for naming CSS selectors. Objects in CSS are separated by single dashes. Multi-word objects are separated by an underscore (For example: `.usa-button-cool_feature-active`).
 * Uses **modular CSS** for scalable, modular, and flexible code.
 * Uses **nesting** when appropriate. Nest minimally with up to two levels of nesting.
-* Hard-coded magic numbers are avoided and, if necessary, defined in the `core/variables` file.
+* Hard-coded magic numbers are avoided and, if necessary, defined in the `core/variables` scss file.
 * Media queries are built **mobile first**.
 * **Spacing units** are as much as possible defined as rem or em units so they scale appropriately with text size. Pixels can be used for detail work and should not exceed 5px (For example: 3px borders).
 
 **For more information, visit:
 [https://pages.18f.gov/frontend/css-coding-styleguide/](https://pages.18f.gov/frontend/css-coding-styleguide/)**
+
+
+## Customization/theming
+
+The standards are ready to be customized to use different typography, colors and grid system. The easiest way to customize the standards is to use Sass and override the standards global variables. If it isn't possible to use Sass, theming must be done by over-riding CSS rules the standards set.
+
+To start theming through Sass, copy the `core/variables` file into your own project's Sass folder, changing applicable variable values, and importing it before the WDS.
+
+```scss
+// src/main.scss
+@import 'src/my-custom-vars';
+@import 'lib/uswds/src/stylesheets/all';
+```
+
+```scss
+// src/_my-custom_vars.scss
+
+// Colors
+$color-primary: #2c3e50;
+$color-secondary: #ad2020;
+$color-secondary-dark: #b0392e;
+
+// Typography
+$font-serif: 'Georgia', 'Times', serif;
+$h2-font-size: 2rem;
+$h3-font-size: 1.75rem;
+$heading-line-height: 1.4;
+
+// Grid/breakpoints
+$small-screen:  540px !default;
+$medium-screen: 620px !default;
+$large-screen:  1120px !default;
+```
+
+Do not every change any code in your `uswds` folder. Doing so could make it impossible to upgrade WDS in the future without undoing your changes.
+
+### Where to find customizable variables
+* Colors can be found in the `core/variables` [file, line 35](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L35).
+* Font families can be found in the `core/variables` [file, line 28](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L28).
+* Typography sizing can be found in `core/variables` [file, line 13](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L13).
+* Grid and breakpoint settings can be found in `core/variables` [file, line 87](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss#L87).
+
 
 ## Where things live<a id="where-things-live"></a>
 


### PR DESCRIPTION


## Description

Includes expanded information on how to customize the WDS with examples and in depth information on what can be customized.

## Additional information

Most of this information was taken from https://github.com/18F/cg-style, as it's a heavily customized version of the WDS. 

Additional information can be found in individual commit messages.

Review needed: copy editing, stylistic, engineering