### PR TITLE
Replace id reference and replace with {{ forloop.index.

### DIFF
--- a/_data/milestones.yml
+++ b/_data/milestones.yml
@@ -4,7 +4,7 @@
       status: done
       url: https://github.com/18F/web-design-standards/milestone/18
     - title: A public maintenance plan.
-      status: in progress
+      status: done
       url: https://github.com/18F/web-design-standards/milestone/19
     - title: A bare-bones HTML starter page, with CSS and JS pre-linked and necessary tags and classes.
       status: in progress

--- a/pages/about-our-work/product-roadmap.md
+++ b/pages/about-our-work/product-roadmap.md
@@ -16,7 +16,7 @@ lead: Here, you’ll find our product roadmap — an up-to-date report on the w
 </ul>
 
 {% for milestone in site.data.milestones %}
-<section id="milestone-{{ milestone.id }}">
+<section id="milestone-{{ forloop.index }}">
   <h2>{{ milestone.title }}</h2>
   <ul>
   {% for task in milestone.tasks %}


### PR DESCRIPTION
Solve to stop duplication of ID's on the product roadmap milestones. Also taking this opportunity to update our roadmap to reflect recent changes/updates to it.

Fixes https://github.com/18F/web-design-standards/issues/1458