### PR TITLE
Adding documentation around Politespace deprecation

### DIFF
--- a/_components/form-templates/02-address-form.md
+++ b/_components/form-templates/02-address-form.md
@@ -36,5 +36,13 @@ order: 02
       <li>If possible, let users type their state’s abbreviation when they reach the state drop-down menu.</li>
       <li>Support both five- and nine-digit ZIP codes. Some addresses require a nine-digit ZIP code.</li>
     </ul>
+    <h4 class="usa-heading">Upgrading address forms (pre version 0.14.0)</h4>
+    <p>The Standards previously leveraged <a href="https://www.filamentgroup.com/lab/politespace.html">Politespace</a> as a way to implement input masking as part of this particular form template, specifically zip code inputs. Our guidance for upgrading is outlined in the following steps:</p>
+    <ul>
+      <li>Be sure to include <a href="https://jquery.com/">jQuery</a> with your assets and include it onto your page.</li>
+      <li>Add the required Politespace files with your other 3rd party assets.</li>
+      <li>Follow <a href="https://github.com/filamentgroup/politespace#using-politespace">the Politespace documentation</a> on how to implement with your form fields.</li>
+    </ul>
+    <p>For any questions or support, please feel free to reach out to the team at <a href="mailto:uswebdesignstandards@gsa.gov.">uswebdesignstandards@gsa.gov.</a></p>
   </div>
 </div>

--- a/_components/form-templates/02-address-form.md
+++ b/_components/form-templates/02-address-form.md
@@ -19,7 +19,6 @@ order: 02
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, make sure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>
-      <li>Also make sure that the input masking on the ZIP field, which inserts a hyphen before the four-digit extension, is accessible to people using screen readers. We use <a href="https://github.com/filamentgroup/politespace">Filament Group's Politespace</a>.</li>
     </ul>
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
@@ -35,7 +34,7 @@ order: 02
     <ul class="usa-content-list">
       <li>Only label the optional inputs. Users can infer that all the others are required.</li>
       <li>If possible, let users type their state’s abbreviation when they reach the state drop-down menu.</li>
-      <li>Support both five- and nine-digit ZIP codes. Some addresses require a nine-digit ZIP code. The input mask should be “#####-####” so that the text is properly formatted, regardless of whether a user enters a five- or nine-digit ZIP code.</li>
+      <li>Support both five- and nine-digit ZIP codes. Some addresses require a nine-digit ZIP code.</li>
     </ul>
   </div>
 </div>

--- a/_components/form-templates/02-address-form.md
+++ b/_components/form-templates/02-address-form.md
@@ -19,6 +19,7 @@ order: 02
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, make sure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>
+      <li>Also make sure that the input masking on the ZIP field, which inserts a hyphen before the four-digit extension, is accessible to people using screen readers. We are using <a href="https://github.com/filamentgroup/politespace">Filament Group's Politespace</a> in the above demo.</li>
     </ul>
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
@@ -34,7 +35,7 @@ order: 02
     <ul class="usa-content-list">
       <li>Only label the optional inputs. Users can infer that all the others are required.</li>
       <li>If possible, let users type their state’s abbreviation when they reach the state drop-down menu.</li>
-      <li>Support both five- and nine-digit ZIP codes. Some addresses require a nine-digit ZIP code.</li>
+      <li>Support both five- and nine-digit ZIP codes. Some addresses require a nine-digit ZIP code. If you would like to use an input mask, it should be “#####-####” so that the text is properly formatted, regardless of whether a user enters a five- or nine-digit ZIP code.</li>
     </ul>
     <h4 class="usa-heading">Upgrading address forms (pre version 0.14.0)</h4>
     <p>The Standards previously leveraged <a href="https://www.filamentgroup.com/lab/politespace.html">Politespace</a> as a way to implement input masking as part of this particular form template, specifically zip code inputs. Our guidance for upgrading is outlined in the following steps:</p>


### PR DESCRIPTION
Submitting this pull request to be merged into the work @shawnbot [has submitted](https://github.com/18F/web-design-standards-docs/pull/82) around adding Politespace as part of the docs site, and not the Standards themselves. 

It is also part of the work started in https://github.com/18F/web-design-standards/pull/1606 too.