### PR TITLE
Add html to use Politespace on address form example

### DIFF
--- a/_includes/code/examples/address-form.html
+++ b/_includes/code/examples/address-form.html
@@ -1,0 +1,80 @@
+
+  <form class="usa-form-large">
+    <fieldset>
+      <legend>Mailing address</legend>
+      <label for="mailing-address-1">Street address 1</label>
+      <input id="mailing-address-1" name="mailing-address-1" type="text">
+
+      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">(Optional)</span></label>
+      <input id="mailing-address-2" name="mailing-address-2" type="text">
+
+      <div>
+        <div class="usa-input-grid usa-input-grid-medium">
+          <label for="city">City</label>
+          <input id="city" name="city" type="text">
+        </div>
+
+        <div class="usa-input-grid usa-input-grid-small">
+          <label for="state">State</label>
+          <select id="state" name="state">
+            <option value></option>
+            <option value="AL">Alabama</option>
+            <option value="AK">Alaska</option>
+            <option value="AZ">Arizona</option>
+            <option value="AR">Arkansas</option>
+            <option value="CA">California</option>
+            <option value="CO">Colorado</option>
+            <option value="CT">Connecticut</option>
+            <option value="DE">Delaware</option>
+            <option value="DC">District of Columbia</option>
+            <option value="FL">Florida</option>
+            <option value="GA">Georgia</option>
+            <option value="HI">Hawaii</option>
+            <option value="ID">Idaho</option>
+            <option value="IL">Illinois</option>
+            <option value="IN">Indiana</option>
+            <option value="IA">Iowa</option>
+            <option value="KS">Kansas</option>
+            <option value="KY">Kentucky</option>
+            <option value="LA">Louisiana</option>
+            <option value="ME">Maine</option>
+            <option value="MD">Maryland</option>
+            <option value="MA">Massachusetts</option>
+            <option value="MI">Michigan</option>
+            <option value="MN">Minnesota</option>
+            <option value="MS">Mississippi</option>
+            <option value="MO">Missouri</option>
+            <option value="MT">Montana</option>
+            <option value="NE">Nebraska</option>
+            <option value="NV">Nevada</option>
+            <option value="NH">New Hampshire</option>
+            <option value="NJ">New Jersey</option>
+            <option value="NM">New Mexico</option>
+            <option value="NY">New York</option>
+            <option value="NC">North Carolina</option>
+            <option value="ND">North Dakota</option>
+            <option value="OH">Ohio</option>
+            <option value="OK">Oklahoma</option>
+            <option value="OR">Oregon</option>
+            <option value="PA">Pennsylvania</option>
+            <option value="RI">Rhode Island</option>
+            <option value="SC">South Carolina</option>
+            <option value="SD">South Dakota</option>
+            <option value="TN">Tennessee</option>
+            <option value="TX">Texas</option>
+            <option value="UT">Utah</option>
+            <option value="VT">Vermont</option>
+            <option value="VA">Virginia</option>
+            <option value="WA">Washington</option>
+            <option value="WV">West Virginia</option>
+            <option value="WI">Wisconsin</option>
+            <option value="WY">Wyoming</option>
+          </select>
+        </div>
+      </div>
+
+      <label for="zip">ZIP</label>
+      <!-- The example below includes the `data-politespace` attribute. This initializes Poltiespace to work with the zip code input. -->
+      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-" data-politespace>
+    </fieldset>
+  </form>

--- a/config/gulp/html.js
+++ b/config/gulp/html.js
@@ -6,7 +6,10 @@ var Prism = require('prismjs');
 
 gulp.task('html', function () {
 
-  return gulp.src('./node_modules/uswds/src/html/**/*.html')
+  return gulp.src([
+      './node_modules/uswds/src/html/**/*.html',
+      '!./node_modules/uswds/src/html/address-form.html',
+      '_includes/code/examples/**/*.html'])
     .pipe(generateCodeSnippets())
     .pipe(gulp.dest('_includes/code/components'));
 


### PR DESCRIPTION
NOTE: This pull request is slated to merge into [the work @shawnbot has started](https://github.com/18F/web-design-standards-docs/pull/82) around isolating Politespace to the website only. The goal is to keep the automation work @rogeruiz developed for creating code samples, but also makes it so that we keep our example of implementing Politespace on our address form example.

:thinking: should we include a link to the JS file on this site to that makes Politespace work? I think a link to the code on Github may suffice.