### PR TITLE
Adds max width overrides that were removed

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -8,6 +8,18 @@
 
 //  -------------- //
 
+.usa-content p:not(.usa-font-lead) {
+  max-width: $text-max-width;
+}
+
+.usa-content-list {
+  max-width: $text-max-width;
+}
+
+.usa-font-lead {
+  max-width: $lead-max-width;
+}
+
 .site-header {
   @include position(fixed, 0 null null 0);
   background-color: $color-primary-darkest;


### PR DESCRIPTION
The max-width overrides were removed in the main WDS code, but we
want to keep them here while the team doesn't have a full visual
designer.

Related to [18F/web-design-standards#ms-removing_max_width](https://github.com/18F/web-design-standards/tree/ms-removing_max_width), but
doesn't require it to be merged.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Follow the [18F Front End Coding Style Guide](https://pages.18f.gov/frontend/) and [Accessibility Guide](https://pages.18f.gov/accessibility/checklist/).
- [x] Run `npm test` and make sure the tests for the files you have changed have passed.
- [x] Run your code through [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/) and make sure it’s error free.
