### PR TITLE
Add closing </li> in accordion deprecation notes

### DIFF
--- a/_components/accordions.md
+++ b/_components/accordions.md
@@ -56,7 +56,7 @@ maturity: alpha
       <li>Remove the top level div that contains the <code>usa-accordion</code> or
       <code>usa-accordion-bordered</code> class.</li>
       <li>Add the <code>usa-accordion</code> or <code>usa-accordion-bordered</code>
-      class to the <code>ul</code> element that's now at the top level.
+      class to the <code>ul</code> element that's now at the top level.</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
We received a note from Kyle Butts in regards to this issue (thank you for your contribution!) and how it is displaying incorrectly on the website. Here is what he wrote in his own words + a screenshot:

> On "18F/web-design-standards-docs/staging/_components/accordions.md”, there is a missing '</li>’ a little above where it says “Deprecated”. Causing a rendering error seen below!

<img width="557" alt="pastedgraphic-1" src="https://cloud.githubusercontent.com/assets/955558/21894974/191530a4-d8af-11e6-936b-a088bc9f534d.png">
