### PR TITLE
Add version field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "uswds-docs",
+  "version": "0.14.0",
   "description": "Website and documentation on using the Draft U.S. Web Design Standards.",
   "scripts": {
     "build": "gulp build && bundle exec jekyll build",


### PR DESCRIPTION
This allows the package to be referenced via another project's `package.json` (via a github URL, not necessarily on npm). Without it, `npm` rejects the package.

⚠️ **I'm going to merge this without a review because I need it to fix the [brand site](/18F/brand).**