### PR TITLE
[WIP] Add blog link

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -61,6 +61,9 @@
       <li>
         <a {% if page.category == 'Page templates' or page.title == 'Page templates' %}class="usa-current"{% endif %} href="/page-templates/">PAGE TEMPLATES</a>
       </li>
+      <li>
+        <a href="https://18f.gsa.gov/tags/web-design-standards/">WHAT’S NEW</a>
+      </li>
     </ul>
   </nav>
 </header>

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -8,7 +8,7 @@
 
   <body class="page-{{ page.title | slugify }}">
 
-  	{% include navbar.html %}
+    {% include navbar.html %}
 
     <aside class="sidenav">
       {% if page.category == 'UI components' or page.title == 'UI components' %}


### PR DESCRIPTION
This adds a blog link (href: https://18f.gsa.gov/tags/web-design-standards/) to the main nav to fix 18F/web-design-standards#1676. It looks like this:

![image](https://cloud.githubusercontent.com/assets/113896/22488560/9f698f02-e7c7-11e6-87a5-3627d3131e37.png)

I'm not sure if we want that external link icon here, but it doesn't bother me _that_ much. Thoughts on the actual link text ("What’s new") or the icon, @bradnunnally @juliaelman?