### PR TITLE
Adding Github release notes to the website

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,8 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'json'
 gem 'redcarpet'
+gem 'hash-joiner'
+gem 'open-uri-cached'
+
 gem 'rouge', '1.9'
 gem 'scss_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,8 @@ GEM
     colorator (1.1.0)
     ffi (1.9.14)
     forwardable-extended (2.6.0)
+    hash-joiner (0.0.7)
+      safe_yaml
     jekyll (3.2.1)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
@@ -25,6 +27,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    open-uri-cached (0.0.5)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     rake (11.2.2)
@@ -43,9 +46,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  hash-joiner
   jekyll
   json
   redcarpet
+  open-uri-cached
   rouge (= 1.9)
   scss_lint
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,10 @@ version: 0.14.0
 permalink: pretty
 google_analytics_ua: UA-48605964-43
 
+jekyll_get:
+  data: releases
+  json: 'https://api.github.com/repos/18F/web-design-standards/releases'
+
 repos:
 - name: Draft U.S. Web Design Standards
   description: Main repository for the Draft U.S. Web Design Standards package

--- a/_plugins/jekyll_get.rb
+++ b/_plugins/jekyll_get.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'hash-joiner'
+require 'open-uri'
+
+module Jekyll_Get
+  class Generator < Jekyll::Generator
+    safe true
+    priority :highest
+
+    def generate(site)
+      config = site.config['jekyll_get']
+      if !config
+        return
+      end
+      if !config.kind_of?(Array)
+        config = [config]
+      end
+      config.each do |d|
+        begin
+          target = site.data[d['data']]
+          source = JSON.load(open(d['json']))
+          if target
+            HashJoiner.deep_merge target, source
+          else
+            site.data[d['data']] = source
+          end
+          if d['cache']
+            data_source = (site.config['data_source'] || '_data')
+            path = "#{data_source}/#{d['data']}.json"
+            open(path, 'wb') do |file|
+              file << JSON.generate(site.data[d['data']])
+            end
+          end
+        rescue
+          next
+        end
+      end
+    end
+  end
+end

--- a/pages/about-our-work/releases.md
+++ b/pages/about-our-work/releases.md
@@ -1,0 +1,17 @@
+---
+permalink: /about-our-work/releases/
+layout: styleguide
+title: What's new
+category: About our work
+---
+<p class="usa-font-lead">The Standards are an ever-evolving product. We've been listening to your feedback and using it as a basis for improvements and additions.</p>
+
+<p class="usa-font-lead">Here you'll find our release notes — summaries of bug fixes, new features, and other updates introduced in each release.</p>
+
+<p>Have suggestions for a new feature or bug fix? Open an <a href="https://github.com/18F/web-design-standards/issues/new" title="Click here to open an issue on Github">issue</a> in our repo.</p>
+
+
+{% for release in site.data.releases %}
+  <h2><a href="{{ release.html_url }}">{{ release.name }}</a></h2>
+  {{ release.body | markdownify }}
+{% endfor %}


### PR DESCRIPTION
This is the initial pull request for getting the release notes onto standards.usa.gov. A few things to note:

- It is using a modified version of ['jekyll_get`](https://github.com/18F/jekyll-get); we could probably remove the caching option, but wanted to work quickly for now and modify as we go.
- This does not make our release notes async. I decided to go this route b/c our release notes *should not* be modified once released. We have been developing a style and layout for them, which is pretty well nailed down at this point.
- There is no link to the release notes in any of the navigation yet. Talked with @bradnunnally and we are good to move forward without that path as part of this initial PR., since that work is currently in progress.

Below is a screenshot for reference:

![screen shot 2017-02-01 at 11 24 31 am](https://cloud.githubusercontent.com/assets/955558/22518296/1bcb5fc8-e87a-11e6-9b91-6189d8b97ada.png)
