### PR TITLE
Update side navigation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,8 @@ DEPENDENCIES
   hash-joiner
   jekyll
   json
-  redcarpet
   open-uri-cached
+  redcarpet
   rouge (= 1.9)
   scss_lint
 

--- a/_includes/sidenav/getting-started.html
+++ b/_includes/sidenav/getting-started.html
@@ -42,7 +42,13 @@
       {% endif %}
     </li>
     <li>
-      <a {% if page.url == '/download/' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/download">Download code and design files</a>
+      <a {% if page.url == '/video-tutorials/' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/video-tutorials">Video Tutorials</a>
+    </li>
+    <li>
+      <a {% if page.url == '/code-guidelines/' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/code-guidelines">Code Guidelines</a>
+    </li>
+    <li>
+      <a {% if page.url == '/product-roadmap/' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/product-roadmap">Product Roadmap</a>
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
Tied to the issue https://github.com/18F/web-design-standards-docs/issues/111

I left Design and Developer links in the side nav, which isn't present in the reference comp. The reason for this is to ensure there is proper way finding around Getting Started when people click that link.

This shouldn't be merged until the other tasks related to updating the site are also complete. 