### PR TITLE
Nix component maturity scale link

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -45,7 +45,6 @@ About our work:
   - text: Overview
     href: /about-our-work/
   - href: /about-our-work/product-roadmap/
-  - href: /about-our-work/component-maturity-scale/
   - href: /about-our-work/research-strategy/
   - href: /about-our-work/current-research/
   - href: /about-our-work/releases/


### PR DESCRIPTION
The "About our work" sidenav is currently busted [on staging](https://standards-staging.usa.gov/about-our-work/). This fixes it by removing the component maturity scale link, the corresponding page for which was removed in #124.

![image](https://cloud.githubusercontent.com/assets/113896/22908939/07f2b8d0-f206-11e6-9c0b-da0ac5165929.png)
