### PR TITLE
Let Jekyll do syntax highlighting

### DIFF
--- a/_includes/code/accordion.html
+++ b/_includes/code/accordion.html
@@ -1,9 +1,10 @@
 <div class="usa-accordion-bordered usa-code-sample">
   <ul class="usa-unstyled-list">
     <li>
-      <button class="usa-button-unstyled" aria-controls="code">Code</button>
-      <div id="code" class="usa-accordion-content">
-        <pre><code class="language-markup">{% include code/components/code-{{ include.component }}.html %}</code></pre>
+      {% assign _id = include.component | prepend: 'code-' %}
+      <button class="usa-button-unstyled" aria-controls="{{ _id }}">Code</button>
+      <div id="{{ _id }}" class="usa-accordion-content">
+        {% include code/syntax.html component=include.component %}
       </div>
     </li>
   </ul>

--- a/_includes/code/demo.html
+++ b/_includes/code/demo.html
@@ -1,1 +1,1 @@
-{% include code/components/preview-{{ include.component }}.html %}
+{% include code/components/{{ include.component }}.html %}

--- a/_includes/code/preview.html
+++ b/_includes/code/preview.html
@@ -1,3 +1,3 @@
 <div class="preview {{ include.classes }}">
-  {% include code/components/preview-{{ include.component }}.html %}
+  {% include code/components/{{ include.component }}.html %}
 </div>

--- a/_includes/code/syntax.html
+++ b/_includes/code/syntax.html
@@ -1,0 +1,5 @@
+{% capture _syntax %}
+```{{ include.language | default: 'html' }}
+{% include code/components/{{ include.component }}.{{ include.language | default: 'html' }} %}
+```
+{% endcapture %}{{ _syntax | markdownify }}

--- a/config/gulp/html.js
+++ b/config/gulp/html.js
@@ -1,44 +1,12 @@
 var gulp = require('gulp');
-var dutil = require('./doc-util');
-var Transform = require('stream').Transform;
-var Path = require('path');
-var Prism = require('prismjs');
 
 gulp.task('html', function () {
 
   return gulp.src([
       './node_modules/uswds/src/html/**/*.html',
       '!./node_modules/uswds/src/html/address-form.html',
-      '_includes/code/examples/**/*.html'])
-    .pipe(generateCodeSnippets())
+      '_includes/code/examples/**/*.html',
+    ])
     .pipe(gulp.dest('_includes/code/components'));
 
 });
-
-function generateCodeSnippets () {
-  var transformStream = new Transform({ objectMode: true });
-
-  transformStream._transform = function (file, encoding, callback) {
-    var error = null;
-    var contents = file.contents.toString();
-    var previewContent = new Buffer(contents);
-    var codeContent = new Buffer(Prism.highlight(contents, Prism.languages.markup));
-    var previewFile = file.clone({ contents: false });
-    var codeFile = file.clone({ contents: false });
-    var previewFileName = 'preview-' + Path.basename(file.path);
-    var codeFileName = 'code-' + Path.basename(file.path);
-
-    dutil.logMessage('generate-code-snippets', 'Generating files for ' + Path.basename(file.path));
-    previewFile.path = Path.join(Path.dirname(previewFile.path), previewFileName);
-    previewFile.contents = previewContent;
-    codeFile.path = Path.join(Path.dirname(codeFile.path), codeFileName);
-    codeFile.contents = codeContent;
-
-    this.push(previewFile);
-    this.push(codeFile);
-
-    callback(error);
-  };
-
-  return transformStream;
-}

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -885,13 +885,8 @@ code {
   code {
     background: none;
     font-size: 1.2rem;
+    margin-top: 0;
     padding: 0;
-  }
-
-  pre {
-    [class*="language-"] {
-      margin-top: 0;
-    }
   }
 
   .usa-unstyled-list {
@@ -903,42 +898,42 @@ code {
   }
 }
 
-// scss-lint:disable QualifyingElement
-code[class*="language-"],
-pre[class*="language-"] {
+[class*="language-"] {
   color: $color-base;
-}
-// scss-lint:enable QualifyingElement
 
-// Custom code sample colors
+  // Custom code sample colors
 
-.token.property,
-.token.tag,
-.token.boolean,
-.token.number,
-.token.constant,
-.token.symbol,
-.token.deleted {
-  color: $color-primary-alt-darkest;
-}
+  .nt,
+  .token.property,
+  .token.tag,
+  .token.boolean,
+  .token.number,
+  .token.constant,
+  .token.symbol,
+  .token.deleted {
+    color: $color-primary-alt-darkest;
+  }
 
-.token.selector,
-.token.attr-name,
-.token.string,
-.token.char,
-.token.builtin,
-.token.inserted {
-  color: $color-secondary;
-}
+  .na,
+  .token.selector,
+  .token.attr-name,
+  .token.string,
+  .token.char,
+  .token.builtin,
+  .token.inserted {
+    color: $color-secondary;
+  }
 
-.token.atrule,
-.token.attr-value,
-.token.keyword {
-  color: $color-green;
-}
+  .s,
+  .token.atrule,
+  .token.attr-value,
+  .token.keyword {
+    color: $color-green;
+  }
 
-.token.punctuation {
-  color: $color-primary-alt-darkest;
+  .token.punctuation {
+    color: $color-primary-alt-darkest;
+  }
 }
 
 .alignment-example {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "normalize.css": "^3.0.3",
     "nswatch": "^0.2.0",
     "politespace": "^0.1.4",
-    "prismjs": "^1.5.1",
     "run-sequence": "^1.1.5",
     "uswds": "~0.14.0",
     "vinyl-buffer": "^1.0.0",


### PR DESCRIPTION
This removes our dependency on [Prism](http://prismjs.com/) for generating syntax-highlighted versions of each of our component includes in the `gulp html` task and (ab)uses the `markdownify` template filter to [generate syntax blocks](https://github.com/18F/web-design-standards-docs/commit/4c8b1970b9f5a9e974c7a2aaab605153d9a1c64d). This change necessitated adding some new token class names to our CSS to match the ones generated by [rouge](http://rouge.jneen.net/) (Jekyll's default syntax highlighter) and [pygments](http://pygments.org/), on which its class names are based.

The new include for including a syntax block for a given component works like this:

```html
{% include code/syntax.html component='accordion' %}
```