### PR TITLE
Update exclude path for SCSS linting.

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,6 +1,6 @@
 scss_files: 'css/**/*.scss'
 
-exclude: 'css/vendor/**'
+exclude: 'assets/css/vendor/**'
 
 # Removes front matter from Jekyll requirements for Sass files
 # See https://github.com/brigade/scss-lint#preprocessing


### PR DESCRIPTION
So that we don't have to deal with seeing this anymore:

```
WARNING: [Bourbon] [Deprecation] `rem` is deprecated and will be removed in 5.0.0.
```

There is also an issue around changing `rem` to `em` on the main Standards repo in [this issue](https://github.com/18F/web-design-standards/issues/992).