### PR TITLE
Change Overview to UI components in nav.yml

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -17,7 +17,7 @@ mobile:
   
 
 UI components:
-  - text: Overview
+  - text: UI components
     href: /components/
   - href: /components/typography/
   - href: /components/colors/

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -17,8 +17,7 @@ mobile:
   
 
 UI components:
-  - text: UI components
-    href: /components/
+  - href: /components/
   - href: /components/typography/
   - href: /components/colors/
   - href: /components/accessibility/


### PR DESCRIPTION
Replacing the term `Overview` with `UI components` to be consistent with our other top level nav elements.