### PR TITLE
Fix image paths and broken link href

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,27 +34,27 @@
         <p>We’re from the government, and we’re here to help.</p>
         <div class="logo-links">
           <a href="https://18f.gsa.gov/">
-            <img src="{{ site.baseurl }}/assets/img/logo-18f.png" alt="18F">
+            <img src="{{ site.baseurl }}/img/logo-18f.png" alt="18F">
           </a>
           <a href="http://www.gsa.gov/">
-            <img src="{{ site.baseurl }}/assets/img/logo-gsa.png" alt="GSA">
+            <img src="{{ site.baseurl }}/img/logo-gsa.png" alt="GSA">
           </a>
         </div>
       </div>
       <div class="usa-footer-contact-links usa-width-one-third">
         <h4>Running into an issue or have a feature request?</h4>
         <a href="{{ site.repos[0].url }}/issues/new" class="usa-button github">
-          <img src="{{ site.baseurl }}/assets/img/logo-github.png" alt="GitHub logo">
+          <img src="{{ site.baseurl }}/img/logo-github.png" alt="GitHub logo">
           Ask questions on GitHub
         </a>
         <h4>Engage with the community</h4>
-        <a href="https://chat.18f.gov./" class="usa-button slack">
-          <img src="{{ site.baseurl }}/assets/img/logo-slack.png" alt="Slack logo">
+        <a href="https://chat.18f.gov/" class="usa-button slack">
+          <img src="{{ site.baseurl }}/img/logo-slack.png" alt="Slack logo">
           Join Slack Channel
         </a>
         <h4>Reach the team</h4>
         <a href="mailto:uswebdesignstandards@gsa.gov" class="usa-button email">
-          <img src="{{ site.baseurl }}/assets/img/logo-email.png" alt="Email logo">
+          <img src="{{ site.baseurl }}/img/logo-email.png" alt="Email logo">
           Send us an email
         </a>          
       </div>


### PR DESCRIPTION
This changes the footer image `src` attributes to reference the `/img/` path ("site" images, vs. USWDS), and removes a stray `.` from the chat.18f.gov URL.