### PR TITLE
Fix :focus on main navigation

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -31,6 +31,8 @@
 
 .site-header {
 
+  background-color: $color-primary-darkest;
+
   @include media($nav-width) {
     border-bottom: none;
   }
@@ -81,11 +83,11 @@
 
 .site-header-navbar {
   border-bottom: none;
-  background-color: $color-primary-darkest;
 
   @include media($nav-width) {
     height: 8rem;
     width: 100%;
+    display: block;
   }
 
   // Firefox fix so that navbar buttons to align right


### PR DESCRIPTION
We were using `display: inherit` which was causing some weird issues in regards to height of the navigation. Also, reset the site header background color on the header instead of on the div.

Screenshot of fix below:

![screen shot 2017-02-22 at 11 26 02 am](https://cloud.githubusercontent.com/assets/955558/23221005/bc115cc6-f8f1-11e6-80e1-29916fcfd4e8.png)
