### PR TITLE
Add home calls to action

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,20 +43,20 @@
       </div>
       <div class="usa-footer-contact-links usa-width-one-third">
         <h5>Find an issue or have a feature request?</h5>
-        <a href="{{ site.repos[0].url }}/issues/new" class="usa-button github">
+        <a href="{{ site.repos[0].url }}/issues/new" class="usa-button cta">
           <img src="{{ site.baseurl }}/img/logo-github.png" alt="GitHub logo">
           Ask questions on GitHub
         </a>
         <h5>Need help troubleshooting?</h5>
-        <a href="https://chat.18f.gov/" class="usa-button slack">
+        <a href="https://chat.18f.gov/" class="usa-button cta">
           <img src="{{ site.baseurl }}/img/logo-slack.png" alt="Slack logo">
           Join our Slack Channel
         </a>
         <h5>Want to hire or contact us?</h5>
-        <a href="mailto:uswebdesignstandards@gsa.gov" class="usa-button email">
+        <a href="mailto:uswebdesignstandards@gsa.gov" class="usa-button cta">
           <img src="{{ site.baseurl }}/img/logo-email.png" alt="Email logo">
           Send us an email
-        </a>          
+        </a>
       </div>
     </div>
   </div>

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -365,6 +365,16 @@ h2 + .tooltip {
   margin-top: 0;
 }
 
+a.cta {
+  img {
+    height: 1.5rem;
+    margin-right: 0.4rem;
+    position: relative;
+    top: 2px;
+    vertical-align: baseline;
+  }
+}
+
 // Footer --------------- //
 
 footer.site {
@@ -394,25 +404,17 @@ footer.site {
   }
 
   .usa-footer-contact-links {
-
     text-align: left;
 
     h4 {
       margin-top: 1em;
     }
 
-    a {
-      color: #FFFFFF;
+    .usa-button {
+      color: $color-white;
       margin-bottom: 0;
       margin-top: 0;
-      padding-left: 35px;
       width: 100%;
-    }
-
-    img {
-      position: relative;
-      top: 1px;
-      width: 15px;
     }
   }
 }

--- a/pages/home.md
+++ b/pages/home.md
@@ -19,6 +19,11 @@ We offer a customized training program to fit your team's needs. The
 product team will provide guidance for getting up and running with
 the U.S. Web Design Standards and kick-start your design and
 development.
+
+<a href="mailto:uswebdesignstandards@gsa.gov" class="usa-button cta">
+  <img src="{{ site.baseurl }}/img/logo-email.png" alt="">
+  Email us to learn more about training
+</a>
 {% endcapture %}
 
 {% capture customization %}
@@ -26,7 +31,13 @@ development.
 
 The product team will partner with you to determine the appropriate
 level of help and customization to make adopting the Standards a
-piece of cake.
+piece of cake. You can also read about customization in our
+[developer guide](getting-started/developers/#customization-and-theming).
+
+<a href="mailto:uswebdesignstandards@gsa.gov" class="usa-button cta">
+  <img src="{{ site.baseurl }}/img/logo-email.png" alt="">
+  Email us to learn more about customization
+</a>
 {% endcapture %}
 
 <div class="usa-grid-full">


### PR DESCRIPTION
Fixes #147. I've added button-like links to the home page for our services:

![image](https://cloud.githubusercontent.com/assets/113896/23238735/476e9d8a-f918-11e6-8e56-0a3a3ee14163.png)

Along the way I also tweaked the icon-in-a-button styles in both these email CTAs and the footer links. Before (left) vs. after (right):

![image](https://cloud.githubusercontent.com/assets/113896/23238843/caa076ce-f918-11e6-96b1-78bc66826009.png)
