### PR TITLE
Change "read more" release link to ref Releases

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -6,7 +6,7 @@ hero:
   callout: Announcing version 1.0
   content: After a year and a half of development and user research, we’re officially launching version 1.0 of the U.S. Web Design Standards. Please explore the site, read our research and documentation, use our code, and join the community!
   button:
-    href: whats-new/product-roadmap/
+    href: whats-new/releases/
     text: Read more about this release
 ---
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -6,7 +6,7 @@ hero:
   callout: Announcing version 1.0
   content: After a year and a half of development and user research, we’re officially launching version 1.0 of the U.S. Web Design Standards. Please explore the site, read our research and documentation, use our code, and join the community!
   button:
-    href: whats-new/releases/
+    href: whats-new/releases/#version-1-0-0
     text: Read more about this release
 ---
 


### PR DESCRIPTION
Our "Read more about this release" CTA link on the home page currently goes to the Product roadmap. This PR points it at our Releases page.