### PR TITLE
Build on Federalist, nix deployment logic

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,20 +1,10 @@
 machine:
-  environment:
-    GOPATH: "${HOME}/.go_workspace"
   node:
     version: 5.1.0
 
 dependencies:
   pre:
-    - mkdir -p debs
-    - if [ ! -f debs/temp.deb ]; then wget -qO debs/temp.deb https://cli.run.pivotal.io/stable?release=debian64; fi
-    - sudo dpkg -i debs/temp.deb
-    - cf -v
-    - go get github.com/concourse/autopilot
-    - cf install-plugin $GOPATH/bin/autopilot -f
     - bundle install
-  cache_directories:
-    - debs
 
 test:
   pre:
@@ -26,23 +16,3 @@ test:
     - npm test # Run the package and test suite
   post:
     - ls -agolf _site/ # Ensure that build worked
-
-deployment:
-  production:
-    branch: master
-    commands:
-      - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-production
-      - cf zero-downtime-push wds-microsite -f manifest.yml -p _site
-      - cf map-route wds-microsite standards.usa.gov
-  staging:
-    branch: staging
-    commands:
-      - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-staging
-      - cf zero-downtime-push wds-microsite -f manifest-staging.yml -p _site
-      - cf map-route wds-microsite standards-staging.usa.gov
-  demo:
-    branch: /demo_.*/
-    commands:
-      - cf login -a https://api.cloud.gov -u gsa-wds_deployer -p $CF_GSA_WDS_PASS -o gsa-wds -s wds-demo
-      - cf push "wds-microsite-$(CIRCLE_BRANCH)" -f manifest-demo.yml -p _site
-      - cf map-route "wds-microsite-$(CIRCLE_BRANCH)" "standards-demo-$(CIRCLE_BRANCH).usa.gov"

--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -41,17 +41,4 @@ gulp.task('scss-lint', function (done) {
 
 });
 
-gulp.task('sass', function (done) {
-
-  dutil.logMessage('sass', 'Compiling Sass');
-
-  runSequence(
-    [
-      'copy-doc-styles',
-      'copy-uswds-styles',
-      'scss-lint'
-    ],
-    done
-  );
-
-});
+gulp.task('sass', ['copy-doc-styles', 'copy-uswds-styles']);

--- a/manifest-demo.yml
+++ b/manifest-demo.yml
@@ -1,4 +1,0 @@
-# Manifest file for automated deployments to our staging environment.
----
-inherit: manifest.yml
-host: wds-microsite-demo

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,4 +1,0 @@
-# Manifest file for automated deployments to our staging environment.
----
-inherit: manifest.yml
-host: wds-microsite-staging

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,0 @@
----
-memory: 64MB
-applications:
-- name: wds-docs
-  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
-  env:
-    FORCE_HTTPS: true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Website and documentation on using the U.S. Web Design Standards.",
   "scripts": {
-    "federalist": "gulp fonts html images javascript copy-doc-styles copy-uswds-styles",
+    "federalist": "gulp build",
     "build": "gulp build && bundle exec jekyll build",
     "build-css": "gulp sass",
     "build-js": "gulp javascript",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Website and documentation on using the U.S. Web Design Standards.",
   "scripts": {
+    "federalist": "gulp build",
     "build": "gulp build && bundle exec jekyll build",
     "build-css": "gulp sass",
     "build-js": "gulp javascript",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Website and documentation on using the U.S. Web Design Standards.",
   "scripts": {
-    "federalist": "gulp build",
+    "federalist": "gulp fonts html images javascript copy-doc-styles copy-uswds-styles",
     "build": "gulp build && bundle exec jekyll build",
     "build-css": "gulp sass",
     "build-js": "gulp javascript",


### PR DESCRIPTION
[😎  Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/federalist/)

This is a fix for all of the code-related tasks in #167:

- [x] Add `federalist` npm script that runs `gulp build`
- [x] Remove `scss-lint` gulp task as `sass` prerequisite, since we don't need linting on Federalist
- [x] Make sure everything works in the [Federalist preview](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/federalist/)
- [x] Remove cloud.gov manifests
- [x] Remove deployment logic from `circle.yml`