### PR TITLE
Adding mobile nav into landing page layout.

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -4,6 +4,18 @@ layout: default
 
 {% include navbar.html %}
 
+<nav role="navigation" class="usa-nav sidenav-mobile">
+  <div class="usa-nav-inner">
+    <button class="usa-nav-close">
+      <img src="{{ site.baseurl }}/assets/img/close.svg" alt="close">
+    </button>
+    <ul class="usa-sidenav-list usa-accordion">
+      {% include nav/sections.html sections=site.data.nav.mobile %}
+    </ul>
+    {% include download-buttons.html %}
+  </div>
+</nav>
+
 <main id="main-content">
   {% if page.hero %}
   <section class="usa-hero">


### PR DESCRIPTION
I was testing out the site this morning and noticed that that mobile nav was not appearing onClick. It looks like we forgot to add that snippet to the new landing page layout. This pull request resolves the issue.