### PR TITLE
Remove padding from <a> in secondary site nav.

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -200,7 +200,6 @@
   }
 
   a {
-    @include padding (1.6rem null);
     color: $color-gray;
     font-size: $h5-font-size;
     font-weight: bold;
@@ -215,7 +214,6 @@
 
     &.usa-current {
       color: $color-primary;
-      font-weight: $font-bold;
     }
   }
 }


### PR DESCRIPTION
We don't need the padding added b/c the `height` property is explicitly set.

I also removed the specific bold attribute for `.usa-current` since that is already the default value.