### PR TITLE
Add trailing period to heading on principles page

### DIFF
--- a/pages/design-principles.md
+++ b/pages/design-principles.md
@@ -21,7 +21,7 @@ lead: "We designed the U.S. Web Design Standards to help you create better exper
     <p>Our patterns and designs are easy to adapt to support the diverse scope and needs of government digital services. The tools and components provided in the USWDS are focused on performance, both from a technical and team based point of view. To ensure this, everything should be validated for the user by the user. The USWDS wants to empower teams across to government to make the statement “good enough for government work” means something again.</p>
   </div>
   <div class="usa-width-one-half">
-    <h2>Showcase benefits for agency and users</h2>
+    <h2>Showcase benefits for agency and users.</h2>
     <p>Teams around the government should easily be able to find inspiration from among their peers. This inspiration can jumpstart many teams own efforts but also lay the groundwork for making the business case for adopting the U.S. Web Design Standards. We will catalog the successes of the Standards and its users both quantitatively and qualitatively.</p>
   </div>
 </div>


### PR DESCRIPTION
The other four headings have one but this one did not.

![screen shot 2017-02-28 at 11 09 40 am](https://cloud.githubusercontent.com/assets/225/23413370/73a1f220-fda6-11e6-94dd-68fea8aed1c4.png)
