### PR TITLE
Add redirect from roadmap from /about-our-work/.

### DIFF
--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -2,6 +2,7 @@
 permalink: /whats-new/product-roadmap/
 redirect_from:
 - /getting-started/product-roadmap/
+- /about-our-work/product-roadmap/
 layout: styleguide
 title: Product roadmap
 category: What’s new


### PR DESCRIPTION
See [this comment](https://github.com/18F/web-design-standards/issues/1477#issuecomment-283094193) for reference on where this re-direct is broken. Tested locally and this works 🆗 