### PR TITLE
Fix location for HTML components

### DIFF
--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -186,7 +186,7 @@ NOTE: If you plan on upgrading to newer versions of the Standards in the future,
 
 ## Where things live
 
-* **HTML** markup for the components are located in: `docs/_components` in the site root.
+* **HTML** markup for the components is located in: `src/html` in the site root.
 * **Sass** styles are located in: `src/stylesheets/ (/core, /elements, /components)`. **Compiled CSS** is located in the [downloadable zip file]({{ site.repos[0].url }}/releases/download/v{{ site.version }}/uswds-{{ site.version }}.zip) .
 * **JS** is located in: `src/js/components (accordion.js, toggle-field-mark.js, toggle-form-input.js, validator.js)`.
 * **Fonts** are located in: `src/fonts`.


### PR DESCRIPTION
The docs were previously migrated, but this instruction had not been updated.

Resolves https://github.com/18F/web-design-standards-docs/issues/192
