### PR TITLE
Disable form submissions on all previews for components

### DIFF
--- a/js/form-disable.js
+++ b/js/form-disable.js
@@ -1,0 +1,5 @@
+var $ = require('jquery');
+
+$('.preview form').submit(function (e) {
+  e.preventDefault();
+});

--- a/js/search.js
+++ b/js/search.js
@@ -1,5 +1,0 @@
-var $ = require('jquery');
-
-$('.preview-search-bar .usa-search').submit(function (event) {
-  event.preventDefault();
-});

--- a/js/start.js
+++ b/js/start.js
@@ -1,10 +1,10 @@
 'use strict';
 
+require('./form-disable');
+require('./scroll-to-top-for-hash');
+require('./sidenav');
 require('./vendor/politespace');
 require('./vendor/stickyfill.min.js');
-require('./scroll-to-top-for-hash');
-require('./search');
-require('./sidenav');
 
 
 // Initialize sticky fill


### PR DESCRIPTION
We originally had this disabled for only the search form component example. This pull request removes that specificity and makes it so that all form submissions are disabled for component examples.