### PR TITLE
Fix skip nav link focus issues in IE11

### DIFF
--- a/_components/page-templates/template-docs.html
+++ b/_components/page-templates/template-docs.html
@@ -116,7 +116,7 @@ layout: demo-templates
       </div>
     </header>
     <div class="usa-overlay"></div>
-    <main class="usa-grid usa-section usa-content usa-layout-docs" id="main-content">
+    <main class="usa-grid usa-section usa-content usa-layout-docs" id="main-content" tabindex="-1">
       <aside class="usa-width-one-fourth usa-layout-docs-sidenav">
         <ul class="usa-sidenav-list">
           <li>

--- a/_components/page-templates/template-landing.html
+++ b/_components/page-templates/template-landing.html
@@ -145,7 +145,7 @@ layout: demo-templates
       </nav>
     </header>
     <div class="usa-overlay"></div>
-    <main id="main-content">
+    <main id="main-content" tabindex="-1">
       <section class="usa-hero">
         <div class="usa-grid">
           <div class="usa-hero-callout usa-section-dark">

--- a/_config.yml
+++ b/_config.yml
@@ -58,18 +58,19 @@ gems:
   - jekyll-redirect-from
 
 exclude:
-- ".ruby-version"
-- ".sass-cache"
-- CONTRIBUTING.md
-- Gemfile
-- Gemfile.lock
-- LICENSE.md
-- README.md
-- config
-- js
-- vendor
-- manifest.yml
-- node_modules
-- package.json
-- gulpfile.js
-- circle.yml
+  - ".ruby-version"
+  - ".sass-cache"
+  - CONTRIBUTING.md
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE.md
+  - README.md
+  - config
+  - js
+  - vendor
+  - manifest.yml
+  - node_modules
+  - package.json
+  - gulpfile.js
+  - circle.yml
+

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<main id="main-content">
+<main id="main-content" tabindex="-1">
   {% if page.hero %}
   <section class="usa-hero">
     <div class="usa-grid">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ category: What’s new
   </ul>
 </aside>
 
-<main class="main-content" id="main-content">
+<main id="main-content" class="main-content" tabindex="-1">
   <div class="styleguide-content usa-content">
   {% if page.collection == 'posts' %}
     {% include post.html post=page %}

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -10,7 +10,7 @@ layout: default
   {% endif %}
 </aside>
 
-<main class="main-content" id="main-content">
+<main id="main-content" class="main-content" tabindex="-1">
 
   <div class="styleguide-content usa-content">
     <header>


### PR DESCRIPTION
[👀 Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/patch-main-tabindex/)

This is a fix for 18F/web-design-standards#1788 that adds `tabindex="-1"` to `<main>` elements throughout the site, which ensures that IE11 (and earlier?) properly focuses the target of the skip navigation link.