### PR TITLE
Fix CBP post excerpt

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -18,11 +18,9 @@
 
   <div class="post-content">
   {% if include.excerpt == true %}
-    {% if post.lead %}
-      {% include lead.html text=post.lead %}
-    {% else %}
-      {{ post.excerpt }}
-    {% endif %}
+    <p class="post-excerpt">
+      {{ post.lead | default: post.excerpt }}
+    </p>
 
     <p class="post-more"><a href="{{ site.baseurl }}{{ post.url }}">Continue reading</a></p>
   {% else %}

--- a/_posts/2017-03-31-u-s-customs-and-border-patrol-case-study.md
+++ b/_posts/2017-03-31-u-s-customs-and-border-patrol-case-study.md
@@ -5,8 +5,8 @@ tags:
 - case study
 - design
 - cbp
-excerpt: "As mentioned in our [recent Q&A with the team at NASA\(https://standards.usa.gov/whats-new/updates/2017/03/21/nasa-journey-with-us-web-design-standards/), the U.S. Web Design Standards team is sitting down with various agencies that are using the Draft Standards. In this second post in our series, we met with the team at the U.S. Customs and Border Protection and learned how they used the  Standards to train, develop, and design their various websites and applications."
 ---
+As mentioned in our [recent Q&A with the team at NASA](https://standards.usa.gov/whats-new/updates/2017/03/21/nasa-journey-with-us-web-design-standards/), the U.S. Web Design Standards team is sitting down with various agencies that are using the Draft Standards. In this second post in our series, we met with the team at the U.S. Customs and Border Protection and learned how they used the  Standards to train, develop, and design their various websites and applications.
 
 **Standards team:** Why did you decide to use the Draft U.S. Web Design Standards?
 
@@ -36,7 +36,5 @@ To assist in CBP redesign efforts, we’ve created a “Step It Up” program th
 **Standards team:** Is there anything our team could do to help you in your efforts?
 
 **U.S. CBP team:** Yes! Our team could use more guidance on mobile form factors and applications. It would be useful to have guidance UI/UX standards for mobile-first products that we could look to when developing applications for particular devices – such as Android, iOS, and Windows devices.
-
-===
 
 We’re looking to learn more from agencies that have used the Standards; if you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at uswebdesignstandards@gsa.gov. You can also chat with the team in the new public Slack channel for the Standards! 


### PR DESCRIPTION
This ensures that the post excerpts are always wrapped in a `<p>` on the news and updates listing, and moves the CBP post excerpt text into the body so that it can be processed as markdown.