### PR TITLE
Fixing broken formatting in typefaces docs

### DIFF
--- a/_components/typography/02-pairing-and-styles.md
+++ b/_components/typography/02-pairing-and-styles.md
@@ -42,9 +42,8 @@ order: 02
               <a href="{{ site.baseurl }}/assets/img/epa-emanifest-screenshot.png">EPA eManifest (screenshot of non-public site)</a>
             </p>
           </aside>
-          <h6 class="usa-heading-alt">Web Hierarchy</h6>
         </div>
-
+        <h6 class="usa-heading-alt">Web Hierarchy</h6>
         <div class="usa-grid usa-typography-example-font">
           <div class="usa-width-one-half">
             <h3 class="usa-display">Display</h3>
@@ -198,9 +197,8 @@ order: 02
               <a href="{{ site.baseurl }}/">U.S. Web Design Standards homepage</a>
             </p>
           </aside>
-          <h6 class="usa-heading-alt">Web Hierarchy</h6>
         </div>
-
+        <h6 class="usa-heading-alt">Web Hierarchy</h6>
         <div class="serif-robust usa-grid usa-typography-example-font">
           <div class="usa-width-one-half">
             <h3 class="usa-display">Display 1</h3>
@@ -376,9 +374,8 @@ order: 02
               <a href="http://playbook.cio.gov">U.S. Digital Service Playbook</a>
             </p>
           </aside>
-          <h6 class="usa-heading-alt">Web Hierarchy</h6>
         </div>
-
+        <h6 class="usa-heading-alt">Web Hierarchy</h6>
         <div class="serif-robust serif-sans-minor serif-body usa-grid usa-typography-example-font">
           <div class="usa-width-one-half">
             <h3 class="usa-display">Display 1</h3>
@@ -548,9 +545,8 @@ order: 02
             <p><span class="usa-label-big">Medium</span></p>
             <p>Exceeds ideal number of fonts by two. May negatively impact page load performance.</p>
           </aside>
-          <h6 class="usa-heading-alt">Web Hierarchy</h6>
         </div>
-
+        <h6 class="usa-heading-alt">Web Hierarchy</h6>
         <div class="sans-style serif-body usa-grid usa-typography-example-font">
           <div class="usa-width-one-half">
             <h3 class="usa-display">Display 1</h3>
@@ -714,9 +710,8 @@ order: 02
               <a href="{{ site.baseurl }}/assets/img/va-appeals-screenshot.png">Department of Veterans Affairs appeals review (screenshot of non-public site)</a>
             </p>
           </aside>
-          <h6 class="usa-heading-alt">Web Hierarchy</h6>
         </div>
-
+        <h6 class="usa-heading-alt">Web Hierarchy</h6>
         <div class="sans-style usa-grid usa-typography-example-font">
           <div class="usa-width-one-half">
             <h3 class="usa-display">Display 1</h3>


### PR DESCRIPTION
![screen shot 2017-04-03 at 5 52 28 pm](https://cloud.githubusercontent.com/assets/776987/24635013/83f4c8a4-1896-11e7-9b59-3df86015d26c.png)

The `h6`s here were inside the wrong container causing the margin-top to not apply.