### PR TITLE
Fix footer nav alignment

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <a href="#">Return to top</a>
   </div>
   <div class="usa-footer-primary-section">
-    <div class="usa-grid-full">
+    <div class="usa-grid">
       <nav class="usa-footer-nav">
         <ul class="usa-unstyled-list">
           <li class="usa-width-one-sixth usa-footer-primary-content">


### PR DESCRIPTION
Before (with `.usa-grid-full`, left) vs. after (`.usa-grid`):

![image](https://cloud.githubusercontent.com/assets/113896/24723950/3e0642d2-19fe-11e7-9b29-ed807d0f6e5e.png)
