### PR TITLE
Hide performance section on Design Principles

### DIFF
--- a/pages/design-principles.html
+++ b/pages/design-principles.html
@@ -34,11 +34,10 @@ principles:
       Standards wants to empower teams across to government to make the
       statement “good enough for government work” mean something again.
 
-  - title: Build for performance.
-    desc: >
-      <span class="usa-label">TKTKTK</span> Each of our patterns,
-      templates, assets, and guidelines should be built to deliver
-      performant experiences.
+#  - title: Build for performance.
+#    desc: >
+#      Each of our patterns, templates, assets, and guidelines is built
+#      with performance in mind.
 
   - title: Showcase benefits for agency and users.
     desc: >


### PR DESCRIPTION
This wraps up #274 by hiding the performance section. We should revive it and flesh out the text when we're ready to publish the rest of the performance guide pages.