### PR TITLE
Fix code (and other) accordions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
-    ffi (1.9.14)
+    ffi (1.9.18)
     forwardable-extended (2.6.0)
     hash-joiner (0.0.7)
       safe_yaml
-    jekyll (3.2.1)
+    jekyll (3.4.3)
+      addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -18,14 +21,14 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-compose (0.5.0)
       jekyll (>= 3.0.0)
-    jekyll-redirect-from (0.10.0)
-      jekyll (>= 2.0)
-    jekyll-sass-converter (1.4.0)
+    jekyll-redirect-from (0.12.1)
+      jekyll (~> 3.3)
+    jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     json (2.0.2)
-    kramdown (1.12.0)
+    kramdown (1.13.2)
     liquid (3.0.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -34,14 +37,15 @@ GEM
     open-uri-cached (0.0.5)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
     rake (11.2.2)
-    rb-fsevent (0.9.7)
-    rb-inotify (0.9.7)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
     rouge (1.9.0)
     safe_yaml (1.0.4)
-    sass (3.4.22)
+    sass (3.4.23)
     scss_lint (0.50.2)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
@@ -61,4 +65,4 @@ DEPENDENCIES
   scss_lint
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/_components/alerts.md
+++ b/_components/alerts.md
@@ -13,10 +13,10 @@ lead: Alerts keep users informed of important and sometimes time-sensitive chang
 {% include code/accordion.html component="alerts" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="alert-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="alert-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>Use the ARIA <code>role=<wbr>"alert"</code> to inform assistive technologies of a time-sensitive and important message that is not interactive. If the message is interactive, use the <code>alertdialog</code> role instead.</li>

--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -13,10 +13,10 @@ lead: Use buttons to signal actions.
 {% include code/accordion.html component="buttons" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="accordion-bordered-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="accordion-bordered-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Implementation</h4>
     <p>The examples demonstrate how to use button elements. To use a button style on an anchor link, add the <code>usa-button</code> class to your anchor link.</p>
     <p>To use a different style button on your anchor link, add the special button class in addition to <code>usa-button</code>:</p>

--- a/_components/figure.md
+++ b/_components/figure.md
@@ -9,10 +9,10 @@ lead: Intro text on what is included in this section and how to use it. No more 
 {% include code/accordion.html component="figure" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="figure-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="figure-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul class="usa-content-list">

--- a/_components/footers.md
+++ b/_components/footers.md
@@ -20,10 +20,10 @@ subnav:
 {% include code/accordion.html component="footers" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="footer-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="footer-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>Code the navigation so that pressing the tab key moves focus from link to link in the navigation, even when the navigation has collapsed into an accordion.</li>

--- a/_components/form-controls/01-text-input.md
+++ b/_components/form-controls/01-text-input.md
@@ -9,10 +9,10 @@ lead: Text inputs allow people to enter any combination of letters, numbers, or 
 {% include code/accordion.html component="text-input" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="text-input-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="text-input-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <p>If you customize the text inputs, ensure they continue to meet the the <a href="{{ site.baseurl }}/form-controls/"> accessibility requirements that apply to all form controls.</a></p>
     <ul class="usa-content-list">

--- a/_components/form-controls/02-dropdown.md
+++ b/_components/form-controls/02-dropdown.md
@@ -10,10 +10,10 @@ lead: A dropdown allows users to select one option from a list.
 {% include code/accordion.html component="dropdown" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="dropdown-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="dropdown-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <p>If you customize the dropdown, ensure it continues to meet the the <a href="{{ site.baseurl }}/form-controls/"> accessibility requirements that apply to all form controls.</a></p>
     <ul class="usa-content-list">

--- a/_components/form-controls/03-checkboxes.md
+++ b/_components/form-controls/03-checkboxes.md
@@ -10,10 +10,10 @@ lead: Checkboxes allow users to select one or more options from a visible list.
 {% include code/accordion.html component="checkboxes" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="checkbox-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="checkbox-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <p>If you customize the text inputs, ensure they continue to meet the the <a href="{{ site.baseurl }}/form-controls/"> accessibility requirements that apply to all form controls.</a></p>
     <ul class="usa-content-list">

--- a/_components/form-controls/04-radio-buttons.md
+++ b/_components/form-controls/04-radio-buttons.md
@@ -9,10 +9,10 @@ lead: Radio buttons allow users to see all available choices at once and select 
 {% include code/accordion.html component="radio-buttons" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="radio-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="radio-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <p>If you customize the radio buttons, ensure they continue to meet the the <a href="{{ site.baseurl }}/form-controls/"> accessibility requirements that apply to all form controls.</a></p>
     <ul class="usa-content-list">

--- a/_components/form-controls/05-date-input.md
+++ b/_components/form-controls/05-date-input.md
@@ -10,10 +10,10 @@ lead: Three text fields are the easiest way for users to enter most dates.
 {% include code/accordion.html component="date-input" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="date-input-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="date-input-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Implementation</h4>
       <p>Currently, the max limit for the year input is set to 2000, but it should be changed depending on the context of the form.</p>
     <h4 class="usa-heading">Accessibility</h4>

--- a/_components/form-templates/01-name-form.md
+++ b/_components/form-templates/01-name-form.md
@@ -9,10 +9,10 @@ lead: A standard template for collecting a person’s full name
 {% include code/accordion.html component="name-form" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="name-form-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="name-form-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, ensure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>

--- a/_components/form-templates/02-address-form.md
+++ b/_components/form-templates/02-address-form.md
@@ -11,10 +11,10 @@ order: 02
 {% include code/accordion.html component="address-form" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="address-form-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="address-form-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, make sure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>

--- a/_components/form-templates/03-sign-in-form.md
+++ b/_components/form-templates/03-sign-in-form.md
@@ -9,10 +9,10 @@ lead: A template for signing a user into a website or app
 {% include code/accordion.html component="sign-in-form" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="signin-form-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="signin-form-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, make sure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>

--- a/_components/form-templates/04-password-reset-form.md
+++ b/_components/form-templates/04-password-reset-form.md
@@ -9,10 +9,10 @@ lead: A standard template for resetting a password
 {% include code/accordion.html component="password-reset" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="password-reset-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="password-reset-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, make sure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>

--- a/_components/grids.md
+++ b/_components/grids.md
@@ -127,10 +127,10 @@ lead: This 12-column, responsive grid provides structure for website content.
 
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="grid-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="grid-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Implementation</h4>
     <p>To use the grid, wrap each grid row in a <code>&lt;div&gt;</code> with the <code>usa-grid</code> class. To use a grid without padding on the right and left, use the <code>usa-grid-full</code> class instead.</p>
     <p>Each grid item is written semantically by its width. For example: <code>usa-width-one-half</code> = 1/2 grid item, <code>usa-width-two-thirds</code> = 2/3 grid item.</p>

--- a/_components/labels.md
+++ b/_components/labels.md
@@ -13,10 +13,10 @@ lead: Labels draw attention to new or important content.
 {% include code/accordion.html component="labels" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="label-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="label-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <p>When labels are used to call out new content that is dynamically loaded onto a page, be sure to use ARIA live regions to alert screen readers of the change.</p>
 

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -13,10 +13,10 @@ lead: A block that allows users to search for specific content if they know what
 {% include code/accordion.html component="search-bar" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="search-bar-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="search-bar-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>As you customize this form template, ensure it continues to follow the <a href="{{ site.baseurl }}/form-templates/">accessibility guidelines for form templates</a> and the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines for form controls</a>.</li>

--- a/_components/sidenav.md
+++ b/_components/sidenav.md
@@ -13,10 +13,10 @@ lead: "Hierarchical, vertical navigation to place at the side of a page. Note: W
 {% include code/accordion.html component="sidenav" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="sidenav-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="sidenav-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>Ensure the side navigational system is keyboard accessible. Users should be able to tab through each link.</li>

--- a/_components/tables.md
+++ b/_components/tables.md
@@ -13,10 +13,10 @@ lead: Tables show tabular data in columns and rows.
 {% include code/accordion.html component="tables" %}
 <div class="usa-accordion-bordered">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="table-docs">
     Documentation
   </button>
-  <div id="collapsible-0" aria-hidden="false" class="usa-accordion-content">
+  <div id="table-docs" aria-hidden="false" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>Simple tables can have two levels of headers. Each header cell should have <code>scope=<wbr>"col"</code> or <code>scope=<wbr>"row"</code>.</li>

--- a/_components/typography/02-pairing-and-styles.md
+++ b/_components/typography/02-pairing-and-styles.md
@@ -12,10 +12,10 @@ order: 02
   <ul class="usa-unstyled-list">
     <li>
       <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-0">
+          aria-expanded="false" aria-controls="font-pairing1-docs">
         <h5>Default: Merriweather headings, Source Sans Pro body (lite)</h5>
       </button>
-      <div id="collapsible-0" class="usa-accordion-content">
+      <div id="font-pairing1-docs" class="usa-accordion-content">
 
         <div class="usa-grid-full">
           <div class="usa-width-two-thirds">
@@ -167,10 +167,10 @@ order: 02
   <ul class="usa-unstyled-list">
     <li>
       <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-0">
+          aria-expanded="false" aria-controls="font-pairing2-docs">
         <h5>Merriweather headings, Source Sans Pro body (robust)</h5>
       </button>
-      <div id="collapsible-0" class="usa-accordion-content">
+      <div id="font-pairing2-docs" class="usa-accordion-content">
 
         <div class="usa-grid-full">
           <div class="usa-width-two-thirds">
@@ -344,10 +344,10 @@ order: 02
   <ul class="usa-unstyled-list">
     <li>
       <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-0">
+          aria-expanded="false" aria-controls="font-pairing3-docs">
         <h5>Merriweather headings and body</h5>
       </button>
-      <div id="collapsible-0" class="usa-accordion-content">
+      <div id="font-pairing3-docs" class="usa-accordion-content">
 
         <div class="usa-grid-full">
           <div class="usa-width-two-thirds">
@@ -521,10 +521,10 @@ order: 02
   <ul class="usa-unstyled-list">
     <li>
       <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-0">
+          aria-expanded="false" aria-controls="font-pairing4-docs">
         <h5>Source Sans Pro headings, Merriweather body</h5>
       </button>
-      <div id="collapsible-0" class="usa-accordion-content">
+      <div id="font-pairing4-docs" class="usa-accordion-content">
 
         <div class="usa-grid-full">
           <div class="usa-width-two-thirds">
@@ -681,10 +681,10 @@ order: 02
   <ul class="usa-unstyled-list">
     <li>
       <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="collapsible-0">
+          aria-expanded="false" aria-controls="font-pairing5-docs">
         <h5>Source Sans Pro headings and body</h5>
       </button>
-      <div id="collapsible-0" class="usa-accordion-content">
+      <div id="font-pairing5-docs" class="usa-accordion-content">
 
         <div class="usa-grid-full">
           <div class="usa-width-two-thirds">

--- a/_components/typography/03-typesetting.md
+++ b/_components/typography/03-typesetting.md
@@ -13,10 +13,10 @@ order: 03
 {% include code/accordion.html component="typesetting" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="typesetting-docs">
     Documentation
   </button>
-  <div id="collapsible-0" class="usa-accordion-content">
+  <div id="typesetting-docs" class="usa-accordion-content">
     <h4 class="usa-heading">Implementation</h4>
     <p>To get the max-width on body text, add the class <code>usa-content</code> to your document. Use at the specificity that best suits your project's needs.</p>
     <p>Lists must use <code>usa-content-list</code> for the above.</p>

--- a/_components/typography/04-links.md
+++ b/_components/typography/04-links.md
@@ -14,10 +14,10 @@ order: 04
 {% include code/accordion.html component="links" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="link-docs">
     Documentation
   </button>
-  <div id="collapsible-0" class="usa-accordion-content">
+  <div id="link-docs" class="usa-accordion-content">
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>Users should be able to tab to navigate between links.</li>

--- a/_components/typography/05-lists.md
+++ b/_components/typography/05-lists.md
@@ -13,12 +13,12 @@ order: 05
 {% include code/accordion.html component="lists" %}
 <div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
-      aria-expanded="true" aria-controls="collapsible-0">
+      aria-expanded="true" aria-controls="list-docs">
     Documentation
   </button>
-  <div id="collapsible-0" class="usa-accordion-content">
-  <h4 class="usa-heading">Implementation</h4>
-  <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>assets/_scss/core/<wbr>utilities.scss</code>.</p>
+  <div id="list-docs" class="usa-accordion-content">
+    <h4 class="usa-heading">Implementation</h4>
+    <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>assets/_scss/core/<wbr>utilities.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
     <ul class="usa-content-list">

--- a/_includes/child-sections.html
+++ b/_includes/child-sections.html
@@ -1,6 +1,6 @@
 {% assign children = site.components | where: 'parent', include.parent | sort: 'order' %}
 {% for child in children %}
-<section id="{{ child.slug }}">
+<section id="section-{{ child.id }}">
   <h2 class="usa-heading heading-margin-alt" id="{{ child.title | slugify }}">{{ child.title }}</h2>
   {% if child.lead != null %}
     <p class="usa-font-lead">{{ child.lead }}</p>

--- a/_includes/code/accordion.html
+++ b/_includes/code/accordion.html
@@ -2,7 +2,7 @@
   <ul class="usa-unstyled-list">
     <li>
       {% assign _id = include.component | prepend: 'code-' %}
-      <button class="usa-button-unstyled" aria-controls="{{ _id }}">Code</button>
+      <button class="usa-accordion-button" aria-controls="{{ _id }}">Code</button>
       <div id="{{ _id }}" class="usa-accordion-content">
         {% include code/syntax.html component=include.component %}
       </div>

--- a/_includes/code/components/accordion.html
+++ b/_includes/code/components/accordion.html
@@ -1,121 +1,119 @@
+<h6>Borderless</h6>
 
-  <h6>Borderless</h6>
+<ul class="usa-accordion">
+  <li>
+    <button class="usa-accordion-button"
+      aria-expanded="true" aria-controls="amendment-1">
+      First Amendment
+    </button>
+    <div id="amendment-1" class="usa-accordion-content">
+      <p>
+      Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+      aria-controls="amendment-2">
+      Second Amendment
+    </button>
+    <div id="amendment-2" class="usa-accordion-content">
+      <p>
+      A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+        aria-controls="amendment-3">
+      Third Amendment
+    </button>
+    <div id="amendment-3" class="usa-accordion-content">
+      <p>
+      No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+      aria-controls="amendment-4">
+      Fourth Amendment
+    </button>
+    <div id="amendment-4" class="usa-accordion-content">
+      <p>
+      The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+      aria-controls="amendment-5">
+      Fifth Amendment
+    </button>
+    <div id="amendment-5" class="usa-accordion-content">
+      <p>
+      No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
+      </p>
+    </div>
+  </li>
+</ul>
 
-  <ul class="usa-accordion">
-    <li>
-      <button class="usa-accordion-button"
-        aria-expanded="true" aria-controls="amendment-1">
-        First Amendment
-      </button>
-      <div id="amendment-1" class="usa-accordion-content">
-        <p>
-        Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-        aria-controls="amendment-2">
-        Second Amendment
-      </button>
-      <div id="amendment-2" class="usa-accordion-content">
-        <p>
-        A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-          aria-controls="amendment-3">
-        Third Amendment
-      </button>
-      <div id="amendment-3" class="usa-accordion-content">
-        <p>
-        No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-        aria-controls="amendment-4">
-        Fourth Amendment
-      </button>
-      <div id="amendment-4" class="usa-accordion-content">
-        <p>
-        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-        aria-controls="amendment-5">
-        Fifth Amendment
-      </button>
-      <div id="amendment-5" class="usa-accordion-content">
-        <p>
-        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
-        </p>
-      </div>
-    </li>
-  </ul>
+<h6>Bordered</h6>
 
-  <h6>Bordered</h6>
-
-  <ul class="usa-accordion-bordered">
-    <li>
-      <button class="usa-accordion-button"
-        aria-expanded="true" aria-controls="amendment-b-1">
-        First Amendment
-      </button>
-      <div id="amendment-b-1" class="usa-accordion-content">
-        <p>
-        Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-        aria-controls="amendment-b-2">
-        Second Amendment
-      </button>
-      <div id="amendment-b-2" class="usa-accordion-content">
-        <p>
-        A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-          aria-controls="amendment-b-3">
-        Third Amendment
-      </button>
-      <div id="amendment-b-3" class="usa-accordion-content">
-        <p>
-        No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-        aria-controls="amendment-b-4">
-        Fourth Amendment
-      </button>
-      <div id="amendment-b-4" class="usa-accordion-content">
-        <p>
-        The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-accordion-button"
-        aria-controls="amendment-b-5">
-        Fifth Amendment
-      </button>
-      <div id="amendment-b-5" class="usa-accordion-content">
-        <p>
-        No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
-        </p>
-      </div>
-    </li>
-  </ul>
-
+<ul class="usa-accordion-bordered">
+  <li>
+    <button class="usa-accordion-button"
+      aria-expanded="true" aria-controls="amendment-b-1">
+      First Amendment
+    </button>
+    <div id="amendment-b-1" class="usa-accordion-content">
+      <p>
+      Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+      aria-controls="amendment-b-2">
+      Second Amendment
+    </button>
+    <div id="amendment-b-2" class="usa-accordion-content">
+      <p>
+      A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+        aria-controls="amendment-b-3">
+      Third Amendment
+    </button>
+    <div id="amendment-b-3" class="usa-accordion-content">
+      <p>
+      No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+      aria-controls="amendment-b-4">
+      Fourth Amendment
+    </button>
+    <div id="amendment-b-4" class="usa-accordion-content">
+      <p>
+      The right of the people to be secure in their persons, houses, papers, and effects, against unreasonable searches and seizures, shall not be violated, and no Warrants shall issue, but upon probable cause, supported by Oath or affirmation, and particularly describing the place to be searched, and the persons or things to be seized.
+      </p>
+    </div>
+  </li>
+  <li>
+    <button class="usa-accordion-button"
+      aria-controls="amendment-b-5">
+      Fifth Amendment
+    </button>
+    <div id="amendment-b-5" class="usa-accordion-content">
+      <p>
+      No person shall be held to answer for a capital, or otherwise infamous crime, unless on a presentment or indictment of a Grand Jury, except in cases arising in the land or naval forces, or in the Militia, when in actual service in time of War or public danger; nor shall any person be subject for the same offence to be twice put in jeopardy of life or limb; nor shall be compelled in any criminal case to be a witness against himself, nor be deprived of life, liberty, or property, without due process of law; nor shall private property be taken for public use, without just compensation.
+      </p>
+    </div>
+  </li>
+</ul>

--- a/_includes/code/components/address-form.html
+++ b/_includes/code/components/address-form.html
@@ -1,80 +1,81 @@
+<form class="usa-form-large">
+  <fieldset>
+    <legend>Mailing address</legend>
+    <label for="mailing-address-1">Street address 1</label>
+    <input id="mailing-address-1" name="mailing-address-1" type="text">
 
-  <form class="usa-form-large">
-    <fieldset>
-      <legend>Mailing address</legend>
-      <label for="mailing-address-1">Street address 1</label>
-      <input id="mailing-address-1" name="mailing-address-1" type="text">
+    <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">(Optional)</span></label>
+    <input id="mailing-address-2" name="mailing-address-2" type="text">
 
-      <label for="mailing-address-2">Street address 2 <span class="usa-additional_text">(Optional)</span></label>
-      <input id="mailing-address-2" name="mailing-address-2" type="text">
-
-      <div>
-        <div class="usa-input-grid usa-input-grid-medium">
-          <label for="city">City</label>
-          <input id="city" name="city" type="text">
-        </div>
-
-        <div class="usa-input-grid usa-input-grid-small">
-          <label for="state">State</label>
-          <select id="state" name="state">
-            <option value></option>
-            <option value="AL">Alabama</option>
-            <option value="AK">Alaska</option>
-            <option value="AZ">Arizona</option>
-            <option value="AR">Arkansas</option>
-            <option value="CA">California</option>
-            <option value="CO">Colorado</option>
-            <option value="CT">Connecticut</option>
-            <option value="DE">Delaware</option>
-            <option value="DC">District of Columbia</option>
-            <option value="FL">Florida</option>
-            <option value="GA">Georgia</option>
-            <option value="HI">Hawaii</option>
-            <option value="ID">Idaho</option>
-            <option value="IL">Illinois</option>
-            <option value="IN">Indiana</option>
-            <option value="IA">Iowa</option>
-            <option value="KS">Kansas</option>
-            <option value="KY">Kentucky</option>
-            <option value="LA">Louisiana</option>
-            <option value="ME">Maine</option>
-            <option value="MD">Maryland</option>
-            <option value="MA">Massachusetts</option>
-            <option value="MI">Michigan</option>
-            <option value="MN">Minnesota</option>
-            <option value="MS">Mississippi</option>
-            <option value="MO">Missouri</option>
-            <option value="MT">Montana</option>
-            <option value="NE">Nebraska</option>
-            <option value="NV">Nevada</option>
-            <option value="NH">New Hampshire</option>
-            <option value="NJ">New Jersey</option>
-            <option value="NM">New Mexico</option>
-            <option value="NY">New York</option>
-            <option value="NC">North Carolina</option>
-            <option value="ND">North Dakota</option>
-            <option value="OH">Ohio</option>
-            <option value="OK">Oklahoma</option>
-            <option value="OR">Oregon</option>
-            <option value="PA">Pennsylvania</option>
-            <option value="RI">Rhode Island</option>
-            <option value="SC">South Carolina</option>
-            <option value="SD">South Dakota</option>
-            <option value="TN">Tennessee</option>
-            <option value="TX">Texas</option>
-            <option value="UT">Utah</option>
-            <option value="VT">Vermont</option>
-            <option value="VA">Virginia</option>
-            <option value="WA">Washington</option>
-            <option value="WV">West Virginia</option>
-            <option value="WI">Wisconsin</option>
-            <option value="WY">Wyoming</option>
-          </select>
-        </div>
+    <div>
+      <div class="usa-input-grid usa-input-grid-medium">
+        <label for="city">City</label>
+        <input id="city" name="city" type="text">
       </div>
 
-      <label for="zip">ZIP</label>
-      <!-- The example below includes the `data-politespace` attribute. This initializes Poltiespace to work with the zip code input. -->
-      <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-" data-politespace>
-    </fieldset>
-  </form>
+      <div class="usa-input-grid usa-input-grid-small">
+        <label for="state">State</label>
+        <select id="state" name="state">
+          <option value></option>
+          <option value="AL">Alabama</option>
+          <option value="AK">Alaska</option>
+          <option value="AZ">Arizona</option>
+          <option value="AR">Arkansas</option>
+          <option value="CA">California</option>
+          <option value="CO">Colorado</option>
+          <option value="CT">Connecticut</option>
+          <option value="DE">Delaware</option>
+          <option value="DC">District of Columbia</option>
+          <option value="FL">Florida</option>
+          <option value="GA">Georgia</option>
+          <option value="HI">Hawaii</option>
+          <option value="ID">Idaho</option>
+          <option value="IL">Illinois</option>
+          <option value="IN">Indiana</option>
+          <option value="IA">Iowa</option>
+          <option value="KS">Kansas</option>
+          <option value="KY">Kentucky</option>
+          <option value="LA">Louisiana</option>
+          <option value="ME">Maine</option>
+          <option value="MD">Maryland</option>
+          <option value="MA">Massachusetts</option>
+          <option value="MI">Michigan</option>
+          <option value="MN">Minnesota</option>
+          <option value="MS">Mississippi</option>
+          <option value="MO">Missouri</option>
+          <option value="MT">Montana</option>
+          <option value="NE">Nebraska</option>
+          <option value="NV">Nevada</option>
+          <option value="NH">New Hampshire</option>
+          <option value="NJ">New Jersey</option>
+          <option value="NM">New Mexico</option>
+          <option value="NY">New York</option>
+          <option value="NC">North Carolina</option>
+          <option value="ND">North Dakota</option>
+          <option value="OH">Ohio</option>
+          <option value="OK">Oklahoma</option>
+          <option value="OR">Oregon</option>
+          <option value="PA">Pennsylvania</option>
+          <option value="RI">Rhode Island</option>
+          <option value="SC">South Carolina</option>
+          <option value="SD">South Dakota</option>
+          <option value="TN">Tennessee</option>
+          <option value="TX">Texas</option>
+          <option value="UT">Utah</option>
+          <option value="VT">Vermont</option>
+          <option value="VA">Virginia</option>
+          <option value="WA">Washington</option>
+          <option value="WV">West Virginia</option>
+          <option value="WI">Wisconsin</option>
+          <option value="WY">Wyoming</option>
+        </select>
+      </div>
+    </div>
+
+    <label for="zip">ZIP</label>
+    <!-- The example below includes the `data-politespace` attribute. This initializes Poltiespace to work with the zip code input. -->
+    <input class="usa-input-medium" id="zip" name="zip" type="text" pattern="[\d]{5}(-[\d]{4})?" data-grouplength="5,4" data-delimiter="-" data-politespace>
+
+    <input type="submit" value="Submit">
+  </fieldset>
+</form>

--- a/_includes/code/components/alerts.html
+++ b/_includes/code/components/alerts.html
@@ -1,36 +1,34 @@
-
-  <div class="usa-alert usa-alert-success">
-    <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Success Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
-    </div>
+<div class="usa-alert usa-alert-success">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Success Status</h3>
+    <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
   </div>
+</div>
 
-  <div class="usa-alert usa-alert-warning">
-    <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Warning Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
-    </div>
+<div class="usa-alert usa-alert-warning">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Warning Status</h3>
+    <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
   </div>
+</div>
 
-  <div class="usa-alert usa-alert-error" role="alert">
-    <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Error Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
-    </div>
+<div class="usa-alert usa-alert-error" role="alert">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Error Status</h3>
+    <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
   </div>
+</div>
 
-  <div class="usa-alert usa-alert-info">
-    <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Information Status</h3>
-      <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
-    </div>
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Information Status</h3>
+    <p class="usa-alert-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.</p>
   </div>
+</div>
 
-  <div class="usa-alert usa-alert-info">
-    <div class="usa-alert-body">
-      <h3 class="usa-alert-heading">Information Status</h3>
-      <p class="usa-alert-text">Multi line. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui atione voluptatem sequi nesciunt. Neque porro quisquam est, qui doloremipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
-    </div>
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Information Status</h3>
+    <p class="usa-alert-text">Multi line. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui atione voluptatem sequi nesciunt. Neque porro quisquam est, qui doloremipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
   </div>
-
+</div>

--- a/_includes/code/components/buttons.html
+++ b/_includes/code/components/buttons.html
@@ -1,55 +1,53 @@
+<h6>Primary Buttons</h6>
+<div class="button_wrapper">
+  <button>Default</button>
+  <button class="usa-button-active">Active</button>
+  <button class="usa-button-hover">Hover</button>
+</div>
+<div class="button_wrapper">
+  <button class="usa-button-primary-alt">Default</button>
+  <button class="usa-button-primary-alt usa-button-active">Active</button>
+  <button class="usa-button-primary-alt usa-button-hover">Hover</button>
+</div>
 
-  <h6>Primary Buttons</h6>
-  <div class="button_wrapper">
-    <button>Default</button>
-    <button class="usa-button-active">Active</button>
-    <button class="usa-button-hover">Hover</button>
-  </div>
-  <div class="button_wrapper">
-    <button class="usa-button-primary-alt">Default</button>
-    <button class="usa-button-primary-alt usa-button-active">Active</button>
-    <button class="usa-button-primary-alt usa-button-hover">Hover</button>
-  </div>
+<h6>Secondary Buttons</h6>
+<div class="button_wrapper">
+  <button class="usa-button-secondary">Default</button>
+  <button class="usa-button-secondary usa-button-active">Active</button>
+  <button class="usa-button-secondary usa-button-hover">Hover</button>
+</div>
 
-  <h6>Secondary Buttons</h6>
-  <div class="button_wrapper">
-    <button class="usa-button-secondary">Default</button>
-    <button class="usa-button-secondary usa-button-active">Active</button>
-    <button class="usa-button-secondary usa-button-hover">Hover</button>
-  </div>
+<div class="button_wrapper">
+  <button class="usa-button-gray">Default</button>
+  <button class="usa-button-gray usa-button-active">Active</button>
+  <button class="usa-button-gray usa-button-hover">Hover</button>
+</div>
 
-  <div class="button_wrapper">
-    <button class="usa-button-gray">Default</button>
-    <button class="usa-button-gray usa-button-active">Active</button>
-    <button class="usa-button-gray usa-button-hover">Hover</button>
-  </div>
+<div class="button_wrapper">
+  <button class="usa-button-outline" type="button">Default</button>
+  <button class="usa-button-outline usa-button-active">Active</button>
+  <button class="usa-button-outline usa-button-hover">Hover</button>
+</div>
 
-  <div class="button_wrapper">
-    <button class="usa-button-outline" type="button">Default</button>
-    <button class="usa-button-outline usa-button-active">Active</button>
-    <button class="usa-button-outline usa-button-hover">Hover</button>
-  </div>
+<div class="button_wrapper button_wrapper-dark">
+  <button class="usa-button-outline-inverse" type="button">Default</button>
+  <button class="usa-button-outline-inverse usa-button-active">Active</button>
+  <button class="usa-button-outline-inverse usa-button-hover">Hover</button>
+</div>
 
-  <div class="button_wrapper button_wrapper-dark">
-    <button class="usa-button-outline-inverse" type="button">Default</button>
-    <button class="usa-button-outline-inverse usa-button-active">Active</button>
-    <button class="usa-button-outline-inverse usa-button-hover">Hover</button>
-  </div>
+<h6>Button Focus</h6>
+<div class="button_wrapper">
+  <button class="usa-button-focus">Default</button>
+  <button class="usa-button-primary-alt usa-button-focus">Default</button>
+  <button class="usa-button-secondary usa-button-focus">Default</button>
+</div>
 
-  <h6>Button Focus</h6>
-  <div class="button_wrapper">
-    <button class="usa-button-focus">Default</button>
-    <button class="usa-button-primary-alt usa-button-focus">Default</button>
-    <button class="usa-button-secondary usa-button-focus">Default</button>
-  </div>
+<h6>Disabled Button</h6>
+<div class="button_wrapper">
+  <button class="usa-button-disabled" disabled>Default</button>
+</div>
 
-  <h6>Disabled Button</h6>
-  <div class="button_wrapper">
-    <button class="usa-button-disabled" disabled>Default</button>
-  </div>
-
-  <h6>Big Button</h6>
-  <div class="button_wrapper">
-    <button class="usa-button-big" type="button">Default</button>
-  </div>
-
+<h6>Big Button</h6>
+<div class="button_wrapper">
+  <button class="usa-button-big" type="button">Default</button>
+</div>

--- a/_includes/code/components/checkboxes.html
+++ b/_includes/code/components/checkboxes.html
@@ -1,26 +1,24 @@
+<fieldset class="usa-fieldset-inputs usa-sans">
 
-  <fieldset class="usa-fieldset-inputs usa-sans">
+  <legend class="usa-sr-only">Historical figures 1</legend>
 
-    <legend class="usa-sr-only">Historical figures 1</legend>
+  <ul class="usa-unstyled-list">
+    <li>
+      <input id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
+      <label for="truth">Sojourner Truth</label>
+    </li>
+    <li>
+      <input id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
+      <label for="douglass">Frederick Douglass</label>
+    </li>
+    <li>
+      <input id="washington" type="checkbox" name="historical-figures-1" value="washington">
+      <label for="washington">Booker T. Washington</label>
+    </li>
+    <li>
+      <input id="carver" type="checkbox" name="historical-figures-1" disabled>
+      <label for="carver">George Washington Carver</label>
+    </li>
+  </ul>
 
-    <ul class="usa-unstyled-list">
-      <li>
-        <input id="truth" type="checkbox" name="historical-figures-1" value="truth" checked>
-        <label for="truth">Sojourner Truth</label>
-      </li>
-      <li>
-        <input id="douglass" type="checkbox" name="historical-figures-1" value="douglass">
-        <label for="douglass">Frederick Douglass</label>
-      </li>
-      <li>
-        <input id="washington" type="checkbox" name="historical-figures-1" value="washington">
-        <label for="washington">Booker T. Washington</label>
-      </li>
-      <li>
-        <input id="carver" type="checkbox" name="historical-figures-1" disabled>
-        <label for="carver">George Washington Carver</label>
-      </li>
-    </ul>
-
-  </fieldset>
-
+</fieldset>

--- a/_includes/code/components/date-input.html
+++ b/_includes/code/components/date-input.html
@@ -1,21 +1,19 @@
+<fieldset>
+  <legend>Date of birth</legend>
+  <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
 
-  <fieldset>
-    <legend>Date of birth</legend>
-    <span class="usa-form-hint" id="dobHint">For example: 04 28 1986</span>
-
-    <div class="usa-date-of-birth">
-      <div class="usa-form-group usa-form-group-month">
-        <label for="date_of_birth_1">Month</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
-      </div>
-      <div class="usa-form-group usa-form-group-day">
-        <label for="date_of_birth_2">Day</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
-      </div>
-      <div class="usa-form-group usa-form-group-year">
-        <label for="date_of_birth_3">Year</label>
-        <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
-      </div>
+  <div class="usa-date-of-birth">
+    <div class="usa-form-group usa-form-group-month">
+      <label for="date_of_birth_1">Month</label>
+      <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
     </div>
-  </fieldset>
-
+    <div class="usa-form-group usa-form-group-day">
+      <label for="date_of_birth_2">Day</label>
+      <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
+    </div>
+    <div class="usa-form-group usa-form-group-year">
+      <label for="date_of_birth_3">Year</label>
+      <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
+    </div>
+  </div>
+</fieldset>

--- a/_includes/code/components/dropdown.html
+++ b/_includes/code/components/dropdown.html
@@ -1,10 +1,10 @@
+<form class="usa-form">
+  <label for="options">Dropdown label</label>
+  <select name="options" id="options">
+    <option value="value1">Option A</option>
+    <option value="value2">Option B</option>
+    <option value="value3">Option C</option>
+  </select>
 
-  <form class="usa-form">
-    <label for="options">Dropdown label</label>
-    <select name="options" id="options">
-      <option value="value1">Option A</option>
-      <option value="value2">Option B</option>
-      <option value="value3">Option C</option>
-    </select>
-  </form>
-
+  <input type="submit" value="Submit">
+</form>

--- a/_includes/code/components/figure.html
+++ b/_includes/code/components/figure.html
@@ -1,9 +1,7 @@
-
-  <div class="usa-image-block">
-    <img src="{{ site.baseurl }}/assets/img/typography_example_apple_pie.png"  alt="Apple Pie">
-    <div class="usa-image-text-block">
-      <h2 class="usa-display">Apple pie</h2>
-      <p class="usa-image-text">It's delicious.</p>
-    </div>
+<div class="usa-image-block">
+  <img src="{{ site.baseurl }}/assets/img/typography_example_apple_pie.png"  alt="Apple Pie">
+  <div class="usa-image-text-block">
+    <h2 class="usa-display">Apple pie</h2>
+    <p class="usa-image-text">It's delicious.</p>
   </div>
-
+</div>

--- a/_includes/code/components/footers.html
+++ b/_includes/code/components/footers.html
@@ -1,192 +1,190 @@
+<h6 class="usa-heading-alt" id="big-footer">Big footer</h6>
 
-  <h6 class="usa-heading-alt" id="big-footer">Big footer</h6>
+<footer class="usa-footer usa-footer-big" role="contentinfo">
+  <div class="usa-grid usa-footer-return-to-top">
+    <a href="#">Return to top</a>
+  </div>
+  <div class="usa-footer-primary-section">
+    <div class="usa-grid-full">
+      <nav class="usa-footer-nav usa-width-two-thirds">
+        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
+          <li class="usa-footer-primary-link">
+            <h4>Topic</h4>
+          </li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+        </ul>
+        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
+          <li class="usa-footer-primary-link">
+            <h4>Topic</h4>
+          </li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+        </ul>
+        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
+          <li class="usa-footer-primary-link">
+            <h4>Topic</h4>
+          </li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+        </ul>
+        <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
+          <li class="usa-footer-primary-link">
+            <h4>Topic</h4>
+          </li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+          <li><a href="javascript:void(0);">Secondary link</a></li>
+        </ul>
+      </nav>
 
-  <footer class="usa-footer usa-footer-big" role="contentinfo">
-    <div class="usa-grid usa-footer-return-to-top">
-      <a href="#">Return to top</a>
+      <div class="usa-sign_up-block usa-width-one-third">
+        <h3 class="usa-sign_up-header">Sign up</h3>
+
+        <label class="" for="email" id="">Your email address</label>
+        <input id="email" name="email" type="email">
+
+        <button type="submit">Sign up</button>
+      </div>
     </div>
-    <div class="usa-footer-primary-section">
-      <div class="usa-grid-full">
-        <nav class="usa-footer-nav usa-width-two-thirds">
-          <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link">
-              <h4>Topic</h4>
-            </li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-          <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link">
-              <h4>Topic</h4>
-            </li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-          <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link">
-              <h4>Topic</h4>
-            </li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-          <ul class="usa-unstyled-list usa-width-one-fourth usa-footer-primary-content">
-            <li class="usa-footer-primary-link">
-              <h4>Topic</h4>
-            </li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-            <li><a href="javascript:void(0);">Secondary link</a></li>
-          </ul>
-        </nav>
+  </div>
 
-        <div class="usa-sign_up-block usa-width-one-third">
-          <h3 class="usa-sign_up-header">Sign up</h3>
+  <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
+    <div class="usa-grid">
+      <div class="usa-footer-logo usa-width-one-half">
+        <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
+        <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+      </div>
+      <div class="usa-footer-contact-links usa-width-one-half">
+        <a class="usa-link-facebook" href="javascript:void(0);">
+          <span>Facebook</span>
+        </a>
+        <a class="usa-link-twitter" href="javascript:void(0);">
+          <span>Twitter</span>
+        </a>
+        <a class="usa-link-youtube" href="javascript:void(0);">
+          <span>YouTube</span>
+        </a>
+        <a class="usa-link-rss" href="javascript:void(0);">
+          <span>RSS</span>
+        </a>
+        <address>
+          <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
+          <p>(800) CALL-GOVT</p>
+          <a href="mailto:info@agency.gov">info@agency.gov</a>
+        </address>
+      </div>
+    </div>
+  </div>
+</footer>
 
-          <label class="" for="email" id="">Your email address</label>
-          <input id="email" name="email" type="email">
+<h6 class="usa-heading-alt" id="medium-footer">Medium footer</h6>
 
-          <button type="submit">Sign up</button>
+<footer class="usa-footer usa-footer-medium" role="contentinfo">
+  <div class="usa-grid usa-footer-return-to-top">
+    <a href="#">Return to top</a>
+  </div>
+  <div class="usa-footer-primary-section">
+    <div class="usa-grid-full">
+      <nav class="usa-footer-nav">
+        <ul class="usa-unstyled-list">
+          <li class="usa-width-one-sixth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-sixth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-sixth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-sixth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-sixth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <div class="usa-footer-secondary_section">
+    <div class="usa-grid">
+      <div class="usa-footer-logo usa-width-one-half">
+        <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
+        <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+      </div>
+      <div class="usa-footer-contact-links usa-width-one-half">
+        <a class="usa-link-facebook" href="javascript:void(0);">
+          <span>Facebook</span>
+        </a>
+        <a class="usa-link-twitter" href="javascript:void(0);">
+          <span>Twitter</span>
+        </a>
+        <a class="usa-link-youtube" href="javascript:void(0);">
+          <span>YouTube</span>
+        </a>
+        <a class="usa-link-rss" href="javascript:void(0);">
+          <span>RSS</span>
+        </a>
+        <address>
+          <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
+          <p>(800) CALL-GOVT</p>
+          <a href="mailto:info@agency.gov">info@agency.gov</a>
+        </address>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<h6 class="usa-heading-alt" id="slim-footer">Slim footer</h6>
+
+<footer class="usa-footer usa-footer-slim" role="contentinfo">
+  <div class="usa-grid usa-footer-return-to-top">
+    <a href="javascript:void(0);">Return to top</a>
+  </div>
+  <div class="usa-footer-primary-section">
+    <div class="usa-grid-full">
+      <nav class="usa-footer-nav usa-width-two-thirds">
+        <ul class="usa-unstyled-list">
+          <li class="usa-width-one-fourth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-fourth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-fourth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+          <li class="usa-width-one-fourth usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+          </li>
+        </ul>
+      </nav>
+      <div class="usa-width-one-third">
+        <div class="usa-footer-primary-content usa-footer-contact_info">
+          <p>(800) CALL-GOVT</p>
+        </div>
+        <div class="usa-footer-primary-content usa-footer-contact_info">
+          <a href="mailto:info@agency.gov">info@agency.gov</a>
         </div>
       </div>
     </div>
+  </div>
 
-    <div class="usa-footer-secondary_section usa-footer-big-secondary-section">
-      <div class="usa-grid">
-        <div class="usa-footer-logo usa-width-one-half">
-          <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
-          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
-        </div>
-        <div class="usa-footer-contact-links usa-width-one-half">
-          <a class="usa-link-facebook" href="javascript:void(0);">
-            <span>Facebook</span>
-          </a>
-          <a class="usa-link-twitter" href="javascript:void(0);">
-            <span>Twitter</span>
-          </a>
-          <a class="usa-link-youtube" href="javascript:void(0);">
-            <span>YouTube</span>
-          </a>
-          <a class="usa-link-rss" href="javascript:void(0);">
-            <span>RSS</span>
-          </a>
-          <address>
-            <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-            <p>(800) CALL-GOVT</p>
-            <a href="mailto:info@agency.gov">info@agency.gov</a>
-          </address>
-        </div>
+  <div class="usa-footer-secondary_section">
+    <div class="usa-grid">
+      <div class="usa-footer-logo">
+        <img class="usa-footer-slim-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
+        <h3 class="usa-footer-slim-logo-heading">Name of Agency</h3>
       </div>
     </div>
-  </footer>
-
-  <h6 class="usa-heading-alt" id="medium-footer">Medium footer</h6>
-
-  <footer class="usa-footer usa-footer-medium" role="contentinfo">
-    <div class="usa-grid usa-footer-return-to-top">
-      <a href="#">Return to top</a>
-    </div>
-    <div class="usa-footer-primary-section">
-      <div class="usa-grid-full">
-        <nav class="usa-footer-nav">
-          <ul class="usa-unstyled-list">
-            <li class="usa-width-one-sixth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-sixth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-sixth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-sixth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-sixth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-
-    <div class="usa-footer-secondary_section">
-      <div class="usa-grid">
-        <div class="usa-footer-logo usa-width-one-half">
-          <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
-          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
-        </div>
-        <div class="usa-footer-contact-links usa-width-one-half">
-          <a class="usa-link-facebook" href="javascript:void(0);">
-            <span>Facebook</span>
-          </a>
-          <a class="usa-link-twitter" href="javascript:void(0);">
-            <span>Twitter</span>
-          </a>
-          <a class="usa-link-youtube" href="javascript:void(0);">
-            <span>YouTube</span>
-          </a>
-          <a class="usa-link-rss" href="javascript:void(0);">
-            <span>RSS</span>
-          </a>
-          <address>
-            <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-            <p>(800) CALL-GOVT</p>
-            <a href="mailto:info@agency.gov">info@agency.gov</a>
-          </address>
-        </div>
-      </div>
-    </div>
-  </footer>
-
-  <h6 class="usa-heading-alt" id="slim-footer">Slim footer</h6>
-
-  <footer class="usa-footer usa-footer-slim" role="contentinfo">
-    <div class="usa-grid usa-footer-return-to-top">
-      <a href="javascript:void(0);">Return to top</a>
-    </div>
-    <div class="usa-footer-primary-section">
-      <div class="usa-grid-full">
-        <nav class="usa-footer-nav usa-width-two-thirds">
-          <ul class="usa-unstyled-list">
-            <li class="usa-width-one-fourth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-fourth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-fourth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-            <li class="usa-width-one-fourth usa-footer-primary-content">
-              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-            </li>
-          </ul>
-        </nav>
-        <div class="usa-width-one-third">
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <p>(800) CALL-GOVT</p>
-          </div>
-          <div class="usa-footer-primary-content usa-footer-contact_info">
-            <a href="mailto:info@agency.gov">info@agency.gov</a>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="usa-footer-secondary_section">
-      <div class="usa-grid">
-        <div class="usa-footer-logo">
-          <img class="usa-footer-slim-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
-          <h3 class="usa-footer-slim-logo-heading">Name of Agency</h3>
-        </div>
-      </div>
-    </div>
-  </footer>
-
+  </div>
+</footer>

--- a/_includes/code/components/header-basic-mega.html
+++ b/_includes/code/components/header-basic-mega.html
@@ -1,211 +1,210 @@
-
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  <header class="usa-header usa-header-basic usa-header-basic-megamenu" role="banner">
-      <!-- Gov banner BEGIN -->
-    <div class="usa-banner">
-      <div class="usa-accordion">
-        <header class="usa-banner-header">
-          <div class="usa-grid usa-banner-inner">
-          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
-          <p>An official website of the United States government</p>
-          <button class="usa-accordion-button usa-banner-button"
-            aria-expanded="false" aria-controls="gov-banner">
-            <span class="usa-banner-button-text">Here's how you know</span>
-          </button>
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<header class="usa-header usa-header-basic usa-header-basic-megamenu" role="banner">
+    <!-- Gov banner BEGIN -->
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+        <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+        <p>An official website of the United States government</p>
+        <button class="usa-accordion-button usa-banner-button"
+          aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner-button-text">Here's how you know</span>
+        </button>
+        </div>
+      </header>
+      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>The .gov means it’s official.</strong>
+              <br>
+              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            </p>
           </div>
-        </header>
-        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-          <div class="usa-banner-guidance-gov usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-body">
-              <p>
-                <strong>The .gov means it’s official.</strong>
-                <br>
-                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-              </p>
-            </div>
-          </div>
-          <div class="usa-banner-guidance-ssl usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-body">
-              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-            </div>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+          <div class="usa-media_block-body">
+            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
           </div>
         </div>
       </div>
     </div>
-    <!-- Gov banner END -->
-    <div class="usa-nav-container">
-      <div class="usa-navbar">
-        <button class="usa-menu-btn">Menu</button>
-        <div class="usa-logo" id="logo">
-          <em class="usa-logo-text">
-            <a href="#" accesskey="1" title="Home" aria-label="Home">Department of <br>Web Standards</a>
-          </em>
-        </div>
+  </div>
+  <!-- Gov banner END -->
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <button class="usa-menu-btn">Menu</button>
+      <div class="usa-logo" id="logo">
+        <em class="usa-logo-text">
+          <a href="#" accesskey="1" title="Home" aria-label="Home">Department of <br>Web Standards</a>
+        </em>
       </div>
-      <nav role="navigation" class="usa-nav">
-        <div class="usa-nav-inner">
-          <button class="usa-nav-close">
-            <img src="/assets/img/close.svg" alt="close">
-          </button>
-          <ul class="usa-nav-primary usa-accordion">
-            <li>
-              <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-1">
-                <span>Section title</span>
-              </button>
-              <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-1">
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-2">
-                <span>Section title</span>
-              </button>
-              <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-2">
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a class="usa-nav-link" href="#">
-                <span>Section title</span>
-              </a>
-            </li>
-            <li>
-              <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-3">
-                <span>Section title</span>
-              </button>
-              <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-3">
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="usa-megamenu-col">
-                  <ul>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                    <li>
-                      <a href="#">Subsection title</a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-          </ul>
-          <form class="usa-search usa-search-small">
-            <div role="search">
-              <label class="usa-sr-only" for="search-field-small">Search small</label>
-              <input id="search-field-small" type="search" name="search">
-              <button type="submit">
-                <span class="usa-sr-only">Search</span>
-              </button>
-            </div>
-          </form>
-        </div>
-      </nav>
     </div>
-  </header>
-  <div class="usa-overlay"></div>
-  <main id="main-content"></main>
+    <nav role="navigation" class="usa-nav">
+      <div class="usa-nav-inner">
+        <button class="usa-nav-close">
+          <img src="/assets/img/close.svg" alt="close">
+        </button>
+        <ul class="usa-nav-primary usa-accordion">
+          <li>
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-1">
+              <span>Section title</span>
+            </button>
+            <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-1">
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-2">
+              <span>Section title</span>
+            </button>
+            <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-2">
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="usa-nav-link" href="#">
+              <span>Section title</span>
+            </a>
+          </li>
+          <li>
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-3">
+              <span>Section title</span>
+            </button>
+            <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-3">
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="usa-megamenu-col">
+                <ul>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                  <li>
+                    <a href="#">Subsection title</a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <form class="usa-search usa-search-small">
+          <div role="search">
+            <label class="usa-sr-only" for="search-field-small">Search small</label>
+            <input id="search-field-small" type="search" name="search">
+            <button type="submit">
+              <span class="usa-sr-only">Search</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </nav>
+  </div>
+</header>
+<div class="usa-overlay"></div>
+<main id="main-content"></main>

--- a/_includes/code/components/header-basic-mega.html
+++ b/_includes/code/components/header-basic-mega.html
@@ -1,6 +1,6 @@
 <a class="usa-skipnav" href="#main-content">Skip to main content</a>
 <header class="usa-header usa-header-basic usa-header-basic-megamenu" role="banner">
-    <!-- Gov banner BEGIN -->
+  <!-- Gov banner BEGIN -->
   <div class="usa-banner">
     <div class="usa-accordion">
       <header class="usa-banner-header">

--- a/_includes/code/components/header-basic.html
+++ b/_includes/code/components/header-basic.html
@@ -1,120 +1,119 @@
-
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  <header class="usa-header usa-header-basic" role="banner">
-    <!-- Gov banner BEGIN -->
-    <div class="usa-banner">
-      <div class="usa-accordion">
-        <header class="usa-banner-header">
-          <div class="usa-grid usa-banner-inner">
-          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
-          <p>An official website of the United States government</p>
-          <button class="usa-accordion-button usa-banner-button"
-            aria-expanded="false" aria-controls="gov-banner">
-            <span class="usa-banner-button-text">Here's how you know</span>
-          </button>
-          </div>
-        </header>
-        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-          <div class="usa-banner-guidance-gov usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-body">
-              <p>
-                <strong>The .gov means it’s official.</strong>
-                <br>
-                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-              </p>
-            </div>
-          </div>
-          <div class="usa-banner-guidance-ssl usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-body">
-              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <!-- Gov banner END -->
-    <div class="usa-nav-container">
-      <div class="usa-navbar">
-        <button class="usa-menu-btn">Menu</button>
-        <div class="usa-logo" id="logo">
-          <em class="usa-logo-text">
-            <a href="#" accesskey="1" title="Home" aria-label="Home">Department of <br>Web Standards</a>
-          </em>
-        </div>
-      </div>
-      <nav role="navigation" class="usa-nav">
-        <button class="usa-nav-close">
-          <img src="/assets/img/close.svg" alt="close">
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<header class="usa-header usa-header-basic" role="banner">
+  <!-- Gov banner BEGIN -->
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+        <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+        <p>An official website of the United States government</p>
+        <button class="usa-accordion-button usa-banner-button"
+          aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner-button-text">Here's how you know</span>
         </button>
-        <ul class="usa-nav-primary usa-accordion">
-          <li>
-            <button class="
-            usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
-              <span>Section title</span>
-            </button>
-            <ul id="side-nav-1" class="usa-nav-submenu">
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
-              <span>Section title</span>
-            </button>
-            <ul id="sidenav-2" class="usa-nav-submenu">
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="usa-nav-link" href="#">
-              <span>Section title</span>
-            </a>
-          </li>
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
-              <span>Section title</span>
-            </button>
-            <ul id="sidenav-3" class="usa-nav-submenu">
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <form class="usa-search usa-search-small">
-          <div role="search">
-            <label class="usa-sr-only" for="search-field-small">Search small</label>
-            <input id="search-field-small" type="search" name="search">
-            <button type="submit">
-              <span class="usa-sr-only">Search</span>
-            </button>
+        </div>
+      </header>
+      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>The .gov means it’s official.</strong>
+              <br>
+              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            </p>
           </div>
-        </form>
-      </nav>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+          <div class="usa-media_block-body">
+            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+          </div>
+        </div>
+      </div>
     </div>
-  </header>
-  <div class="usa-overlay"></div>
-  <main id="main-content"></main>
+  </div>
+  <!-- Gov banner END -->
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <button class="usa-menu-btn">Menu</button>
+      <div class="usa-logo" id="logo">
+        <em class="usa-logo-text">
+          <a href="#" accesskey="1" title="Home" aria-label="Home">Department of <br>Web Standards</a>
+        </em>
+      </div>
+    </div>
+    <nav role="navigation" class="usa-nav">
+      <button class="usa-nav-close">
+        <img src="/assets/img/close.svg" alt="close">
+      </button>
+      <ul class="usa-nav-primary usa-accordion">
+        <li>
+          <button class="
+          usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
+            <span>Section title</span>
+          </button>
+          <ul id="side-nav-1" class="usa-nav-submenu">
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
+            <span>Section title</span>
+          </button>
+          <ul id="sidenav-2" class="usa-nav-submenu">
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a class="usa-nav-link" href="#">
+            <span>Section title</span>
+          </a>
+        </li>
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
+            <span>Section title</span>
+          </button>
+          <ul id="sidenav-3" class="usa-nav-submenu">
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <form class="usa-search usa-search-small">
+        <div role="search">
+          <label class="usa-sr-only" for="search-field-small">Search small</label>
+          <input id="search-field-small" type="search" name="search">
+          <button type="submit">
+            <span class="usa-sr-only">Search</span>
+          </button>
+        </div>
+      </form>
+    </nav>
+  </div>
+</header>
+<div class="usa-overlay"></div>
+<main id="main-content"></main>

--- a/_includes/code/components/header-extended-mega.html
+++ b/_includes/code/components/header-extended-mega.html
@@ -1,222 +1,221 @@
-
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  <header class="usa-header usa-header-extended" role="banner">
-    <!-- Gov banner BEGIN -->
-    <div class="usa-banner">
-      <div class="usa-accordion">
-        <header class="usa-banner-header">
-          <div class="usa-grid usa-banner-inner">
-          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
-          <p>An official website of the United States government</p>
-          <button class="usa-accordion-button usa-banner-button"
-            aria-expanded="false" aria-controls="gov-banner">
-            <span class="usa-banner-button-text">Here's how you know</span>
-          </button>
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<header class="usa-header usa-header-extended" role="banner">
+  <!-- Gov banner BEGIN -->
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+        <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+        <p>An official website of the United States government</p>
+        <button class="usa-accordion-button usa-banner-button"
+          aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner-button-text">Here's how you know</span>
+        </button>
+        </div>
+      </header>
+      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>The .gov means it’s official.</strong>
+              <br>
+              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            </p>
           </div>
-        </header>
-        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-          <div class="usa-banner-guidance-gov usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-body">
-              <p>
-                <strong>The .gov means it’s official.</strong>
-                <br>
-                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-              </p>
-            </div>
-          </div>
-          <div class="usa-banner-guidance-ssl usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-body">
-              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-            </div>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+          <div class="usa-media_block-body">
+            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
           </div>
         </div>
       </div>
     </div>
-    <!-- Gov banner END -->
-    <div class="usa-navbar">
-      <button class="usa-menu-btn">Menu</button>
-      <div class="usa-logo" id="logo">
-        <em class="usa-logo-text">
-          <a href="#" accesskey="1" title="Home" aria-label="Home">Department of Web Standards</a>
-        </em>
-      </div>
+  </div>
+  <!-- Gov banner END -->
+  <div class="usa-navbar">
+    <button class="usa-menu-btn">Menu</button>
+    <div class="usa-logo" id="logo">
+      <em class="usa-logo-text">
+        <a href="#" accesskey="1" title="Home" aria-label="Home">Department of Web Standards</a>
+      </em>
     </div>
-    <nav role="navigation" class="usa-nav">
-      <div class="usa-nav-inner">
-        <button class="usa-nav-close">
-          <img src="/assets/img/close.svg" alt="close">
-        </button>
-        <ul class="usa-nav-primary usa-accordion">
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-1">
-              <span>Section title</span>
-            </button>
-            <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-1">
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-2">
-              <span>Section title</span>
-            </button>
-            <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-2">
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="usa-nav-link" href="#">
-              <span>Section title</span>
-            </a>
-          </li>
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-3">
-              <span>Section title</span>
-            </button>
-            <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-3">
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-              <li class="usa-megamenu-col">
-                <ul>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                  <li>
-                    <a href="#">Subsection title</a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <div class="usa-nav-secondary">
-          <form class="usa-search usa-search-small js-search-form">
-            <div role="search">
-              <label class="usa-sr-only" for="search-field-small">Search small</label>
-              <input id="search-field-small" type="search" name="search">
-              <button type="submit">
-                <span class="usa-sr-only">Search</span>
-              </button>
-            </div>
-          </form>
-          <ul class="usa-unstyled-list usa-nav-secondary-links">
-            <li class="js-search-button-container">
-              <button class="usa-header-search-button js-search-button">Search</button>
+  </div>
+  <nav role="navigation" class="usa-nav">
+    <div class="usa-nav-inner">
+      <button class="usa-nav-close">
+        <img src="/assets/img/close.svg" alt="close">
+      </button>
+      <ul class="usa-nav-primary usa-accordion">
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-1">
+            <span>Section title</span>
+          </button>
+          <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-1">
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
             </li>
-            <li>
-              <a href="#">Secondary link</a>
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
             </li>
-            <li>
-              <a href="#">Secondary link</a>
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
             </li>
           </ul>
-        </div>
+        </li>
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-2">
+            <span>Section title</span>
+          </button>
+          <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-2">
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
+            </li>
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
+            </li>
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a class="usa-nav-link" href="#">
+            <span>Section title</span>
+          </a>
+        </li>
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="megamenu-3">
+            <span>Section title</span>
+          </button>
+          <ul class="usa-nav-submenu usa-megamenu usa-grid-full" id="megamenu-3">
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
+            </li>
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
+            </li>
+            <li class="usa-megamenu-col">
+              <ul>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+                <li>
+                  <a href="#">Subsection title</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <div class="usa-nav-secondary">
+        <form class="usa-search usa-search-small js-search-form">
+          <div role="search">
+            <label class="usa-sr-only" for="search-field-small">Search small</label>
+            <input id="search-field-small" type="search" name="search">
+            <button type="submit">
+              <span class="usa-sr-only">Search</span>
+            </button>
+          </div>
+        </form>
+        <ul class="usa-unstyled-list usa-nav-secondary-links">
+          <li class="js-search-button-container">
+            <button class="usa-header-search-button js-search-button">Search</button>
+          </li>
+          <li>
+            <a href="#">Secondary link</a>
+          </li>
+          <li>
+            <a href="#">Secondary link</a>
+          </li>
+        </ul>
       </div>
-    </nav>
-  </header>
-  <div class="usa-overlay"></div>
-  <main id="main-content"></main>
+    </div>
+  </nav>
+</header>
+<div class="usa-overlay"></div>
+<main id="main-content"></main>

--- a/_includes/code/components/header-extended.html
+++ b/_includes/code/components/header-extended.html
@@ -1,133 +1,132 @@
-
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  <header class="usa-header usa-header-extended" role="banner">
-    <!-- Gov banner BEGIN -->
-    <div class="usa-banner">
-      <div class="usa-accordion">
-        <header class="usa-banner-header">
-          <div class="usa-grid usa-banner-inner">
-          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
-          <p>An official website of the United States government</p>
-          <button class="usa-accordion-button usa-banner-button"
-            aria-expanded="false" aria-controls="gov-banner">
-            <span class="usa-banner-button-text">Here's how you know</span>
-          </button>
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<header class="usa-header usa-header-extended" role="banner">
+  <!-- Gov banner BEGIN -->
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+        <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+        <p>An official website of the United States government</p>
+        <button class="usa-accordion-button usa-banner-button"
+          aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner-button-text">Here's how you know</span>
+        </button>
+        </div>
+      </header>
+      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>The .gov means it’s official.</strong>
+              <br>
+              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            </p>
           </div>
-        </header>
-        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-          <div class="usa-banner-guidance-gov usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-            <div class="usa-media_block-body">
-              <p>
-                <strong>The .gov means it’s official.</strong>
-                <br>
-                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-              </p>
-            </div>
-          </div>
-          <div class="usa-banner-guidance-ssl usa-width-one-half">
-            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-            <div class="usa-media_block-body">
-              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-            </div>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+          <div class="usa-media_block-body">
+            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
           </div>
         </div>
       </div>
     </div>
-    <!-- Gov banner END -->
-    <div class="usa-navbar">
-      <button class="usa-menu-btn">Menu</button>
-      <div class="usa-logo" id="logo">
-        <em class="usa-logo-text">
-          <a href="#" accesskey="1" title="Home" aria-label="Home">Department of Web Standards</a>
-        </em>
-      </div>
+  </div>
+  <!-- Gov banner END -->
+  <div class="usa-navbar">
+    <button class="usa-menu-btn">Menu</button>
+    <div class="usa-logo" id="logo">
+      <em class="usa-logo-text">
+        <a href="#" accesskey="1" title="Home" aria-label="Home">Department of Web Standards</a>
+      </em>
     </div>
-    <nav role="navigation" class="usa-nav">
-      <div class="usa-nav-inner">
-        <button class="usa-nav-close">
-          <img src="/assets/img/close.svg" alt="close">
-        </button>
-        <ul class="usa-nav-primary usa-accordion">
-          <li>
-            <button class="
-            usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
-              <span>Section title</span>
-            </button>
-            <ul id="side-nav-1" class="usa-nav-submenu">
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
-              <span>Section title</span>
-            </button>
-            <ul id="sidenav-2" class="usa-nav-submenu">
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="usa-nav-link" href="#">
-              <span>Section title</span>
-            </a>
-          </li>
-          <li>
-            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
-              <span>Section title</span>
-            </button>
-            <ul id="sidenav-3" class="usa-nav-submenu">
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-              <li>
-                <a href="#">Subsection title</a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <div class="usa-nav-secondary">
-          <form class="usa-search usa-search-small js-search-form">
-            <div role="search">
-              <label class="usa-sr-only" for="search-field-small">Search small</label>
-              <input id="search-field-small" type="search" name="search">
-              <button type="submit">
-                <span class="usa-sr-only">Search</span>
-              </button>
-            </div>
-          </form>
-          <ul class="usa-unstyled-list usa-nav-secondary-links">
-            <li class="js-search-button-container">
-              <button class="usa-header-search-button js-search-button">Search</button>
+  </div>
+  <nav role="navigation" class="usa-nav">
+    <div class="usa-nav-inner">
+      <button class="usa-nav-close">
+        <img src="/assets/img/close.svg" alt="close">
+      </button>
+      <ul class="usa-nav-primary usa-accordion">
+        <li>
+          <button class="
+          usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
+            <span>Section title</span>
+          </button>
+          <ul id="side-nav-1" class="usa-nav-submenu">
+            <li>
+              <a href="#">Subsection title</a>
             </li>
             <li>
-              <a href="#">Secondary link</a>
+              <a href="#">Subsection title</a>
             </li>
             <li>
-              <a href="#">Secondary link</a>
+              <a href="#">Subsection title</a>
             </li>
           </ul>
-        </div>
+        </li>
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
+            <span>Section title</span>
+          </button>
+          <ul id="sidenav-2" class="usa-nav-submenu">
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a class="usa-nav-link" href="#">
+            <span>Section title</span>
+          </a>
+        </li>
+        <li>
+          <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
+            <span>Section title</span>
+          </button>
+          <ul id="sidenav-3" class="usa-nav-submenu">
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+            <li>
+              <a href="#">Subsection title</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <div class="usa-nav-secondary">
+        <form class="usa-search usa-search-small js-search-form">
+          <div role="search">
+            <label class="usa-sr-only" for="search-field-small">Search small</label>
+            <input id="search-field-small" type="search" name="search">
+            <button type="submit">
+              <span class="usa-sr-only">Search</span>
+            </button>
+          </div>
+        </form>
+        <ul class="usa-unstyled-list usa-nav-secondary-links">
+          <li class="js-search-button-container">
+            <button class="usa-header-search-button js-search-button">Search</button>
+          </li>
+          <li>
+            <a href="#">Secondary link</a>
+          </li>
+          <li>
+            <a href="#">Secondary link</a>
+          </li>
+        </ul>
       </div>
-    </nav>
-  </header>
-  <div class="usa-overlay"></div>
-  <main id="main-content"></main>
+    </div>
+  </nav>
+</header>
+<div class="usa-overlay"></div>
+<main id="main-content"></main>

--- a/_includes/code/components/labels.html
+++ b/_includes/code/components/labels.html
@@ -1,7 +1,5 @@
+<h6>Small</h6>
+<span class="usa-label">New</span>
 
-  <h6>Small</h6>
-  <span class="usa-label">New</span>
-
-  <h6>Large</h6>
-  <span class="usa-label-big">New</span>
-
+<h6>Large</h6>
+<span class="usa-label-big">New</span>

--- a/_includes/code/components/links.html
+++ b/_includes/code/components/links.html
@@ -1,11 +1,9 @@
+<p><a href="javascript:void(0);">This</a> is a text link on a light background.</p>
 
-  <p><a href="javascript:void(0);">This</a> is a text link on a light background.</p>
+<p><a class="usa-color-text-visited" href="javascript:void(0);">This</a> is a visited link.</p>
 
-  <p><a class="usa-color-text-visited" href="javascript:void(0);">This</a> is a visited link.</p>
+<p>This is a link that goes to an <a class="usa-external_link" href="http://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif">external website</a>.</p>
 
-  <p>This is a link that goes to an <a class="usa-external_link" href="http://media.giphy.com/media/8sgNa77Dvj7tC/giphy.gif">external website</a>.</p>
-
-  <div class="usa-background-dark">
-    <p><a href="javascript:void(0);">This</a> is a text link on a dark background.</p>
-  </div>
-
+<div class="usa-background-dark">
+  <p><a href="javascript:void(0);">This</a> is a text link on a dark background.</p>
+</div>

--- a/_includes/code/components/lists.html
+++ b/_includes/code/components/lists.html
@@ -1,27 +1,25 @@
+<div class="usa-grid-full">
+  <div class="usa-width-one-third">
 
-  <div class="usa-grid-full">
-    <div class="usa-width-one-third">
+    <h6 class="usa-heading-alt">Unordered list</h6>
 
-      <h6 class="usa-heading-alt">Unordered list</h6>
+    <ul>
+      <li>Unordered list item</li>
+      <li>Unordered list item</li>
+      <li>Unordered list item</li>
+    </ul>
 
-      <ul>
-        <li>Unordered list item</li>
-        <li>Unordered list item</li>
-        <li>Unordered list item</li>
-      </ul>
-
-    </div>
-
-    <div class="usa-width-one-third">
-
-      <h6 class="usa-heading-alt mt0">Ordered list</h6>
-
-      <ol>
-        <li>Ordered list item</li>
-        <li>Ordered list item</li>
-        <li>Ordered list item</li>
-      </ol>
-
-    </div>
   </div>
 
+  <div class="usa-width-one-third">
+
+    <h6 class="usa-heading-alt mt0">Ordered list</h6>
+
+    <ol>
+      <li>Ordered list item</li>
+      <li>Ordered list item</li>
+      <li>Ordered list item</li>
+    </ol>
+
+  </div>
+</div>

--- a/_includes/code/components/name-form.html
+++ b/_includes/code/components/name-form.html
@@ -1,20 +1,21 @@
+<form class="usa-form">
+  <fieldset>
+    <legend>Name</legend>
+    <label for="title">Title</label>
+    <input class="usa-input-tiny" id="title" name="title" type="text">
 
-  <form class="usa-form">
-    <fieldset>
-      <legend>Name</legend>
-      <label for="title">Title</label>
-      <input class="usa-input-tiny" id="title" name="title" type="text">
+    <label for="first-name" class="usa-input-required">First name</label>
+    <input id="first-name" name="first-name" type="text" required="" aria-required="true">
 
-      <label for="first-name" class="usa-input-required">First name</label>
-      <input id="first-name" name="first-name" type="text" required="" aria-required="true">
+    <label for="middle-name">Middle name</label>
+    <input id="middle-name" name="middle-name" type="text">
 
-      <label for="middle-name">Middle name</label>
-      <input id="middle-name" name="middle-name" type="text">
+    <label for="last-name" class="usa-input-required">Last name</label>
+    <input id="last-name" name="last-name" type="text" required="" aria-required="true">
 
-      <label for="last-name" class="usa-input-required">Last name</label>
-      <input id="last-name" name="last-name" type="text" required="" aria-required="true">
+    <label for="suffix">Suffix</label>
+    <input class="usa-input-tiny" id="suffix" name="suffix" type="text">
 
-      <label for="suffix">Suffix</label>
-      <input class="usa-input-tiny" id="suffix" name="suffix" type="text">
-    </fieldset>
-  </form>
+    <input type="submit" value="Submit">
+  </fieldset>
+</form>

--- a/_includes/code/components/password-reset.html
+++ b/_includes/code/components/password-reset.html
@@ -7,7 +7,7 @@
       <div class="usa-alert-body">
         <h3 class="usa-alert-heading">Passwords must:</h3>
       </div>
-      <ul class="usa-checklist" id="validation_list">
+      <ul class="usa-checklist" id="validate-password-reset">
         <li data-validator="length">Be at least 8 characters</li>
         <li data-validator="uppercase">Have at least 1 uppercase character</li>
         <li data-validator="numerical">Have at least 1 numerical character</li>
@@ -15,21 +15,22 @@
       </ul>
     </div>
 
-    <label for="password">New password</label>
-    <input id="password" name="password" type="password"
-      aria-describedby="validation_list"
+    <label for="new-password">New password</label>
+    <input id="new-password" name="password" type="password"
+      aria-describedby="validate-password-reset"
       class="js-validate_password"
       data-validate-length=".{8,}"
       data-validate-uppercase="[A-Z]"
       data-validate-numerical="\d"
-      data-validation-element="#validation_list">
+      data-validation-element="#validate-password-reset">
 
-    <label for="confirmPassword">Confirm password</label>
-    <input id="confirmPassword" name="confirmPassword" type="password">
+    <label for="confirm-password">Confirm password</label>
+    <input id="confirm-password" name="confirmPassword" type="password">
+
     <p class="usa-form-note">
       <a title="Show my typing" href="javascript:void(0);"
           class="usa-show_multipassword"
-          aria-controls="password confirmPassword">
+          aria-controls="new-password confirm-password">
         Show my typing</a>
     </p>
 

--- a/_includes/code/components/password-reset.html
+++ b/_includes/code/components/password-reset.html
@@ -1,40 +1,38 @@
+<form class="usa-form">
+  <fieldset>
+    <legend class="usa-drop_text">Reset password</legend>
+    <span class="usa-serif">Please enter your new password</span>
 
-  <form class="usa-form">
-    <fieldset>
-      <legend class="usa-drop_text">Reset password</legend>
-      <span class="usa-serif">Please enter your new password</span>
-
-      <div class="usa-alert usa-alert-info">
-        <div class="usa-alert-body">
-          <h3 class="usa-alert-heading">Passwords must:</h3>
-        </div>
-        <ul class="usa-checklist" id="validation_list">
-          <li data-validator="length">Be at least 8 characters</li>
-          <li data-validator="uppercase">Have at least 1 uppercase character</li>
-          <li data-validator="numerical">Have at least 1 numerical character</li>
-          <li>Another requirement</li>
-        </ul>
+    <div class="usa-alert usa-alert-info">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Passwords must:</h3>
       </div>
+      <ul class="usa-checklist" id="validation_list">
+        <li data-validator="length">Be at least 8 characters</li>
+        <li data-validator="uppercase">Have at least 1 uppercase character</li>
+        <li data-validator="numerical">Have at least 1 numerical character</li>
+        <li>Another requirement</li>
+      </ul>
+    </div>
 
-      <label for="password">New password</label>
-      <input id="password" name="password" type="password"
-        aria-describedby="validation_list"
-        class="js-validate_password"
-        data-validate-length=".{8,}"
-        data-validate-uppercase="[A-Z]"
-        data-validate-numerical="\d"
-        data-validation-element="#validation_list">
+    <label for="password">New password</label>
+    <input id="password" name="password" type="password"
+      aria-describedby="validation_list"
+      class="js-validate_password"
+      data-validate-length=".{8,}"
+      data-validate-uppercase="[A-Z]"
+      data-validate-numerical="\d"
+      data-validation-element="#validation_list">
 
-      <label for="confirmPassword">Confirm password</label>
-      <input id="confirmPassword" name="confirmPassword" type="password">
-      <p class="usa-form-note">
-        <a title="Show my typing" href="javascript:void(0);"
-            class="usa-show_multipassword"
-            aria-controls="password confirmPassword">
-          Show my typing</a>
-      </p>
+    <label for="confirmPassword">Confirm password</label>
+    <input id="confirmPassword" name="confirmPassword" type="password">
+    <p class="usa-form-note">
+      <a title="Show my typing" href="javascript:void(0);"
+          class="usa-show_multipassword"
+          aria-controls="password confirmPassword">
+        Show my typing</a>
+    </p>
 
-      <input type="submit" value="Reset password" />
-    </fieldset>
-  </form>
-
+    <input type="submit" value="Reset password">
+  </fieldset>
+</form>

--- a/_includes/code/components/radio-buttons.html
+++ b/_includes/code/components/radio-buttons.html
@@ -1,22 +1,20 @@
+<fieldset class="usa-fieldset-inputs usa-sans">
 
-  <fieldset class="usa-fieldset-inputs usa-sans">
+  <legend class="usa-sr-only">Historical figures 2</legend>
 
-    <legend class="usa-sr-only">Historical figures 2</legend>
+  <ul class="usa-unstyled-list">
+    <li>
+      <input id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
+      <label for="stanton">Elizabeth Cady Stanton</label>
+    </li>
+    <li>
+      <input id="anthony" type="radio" name="historical-figures-2" value="anthony">
+      <label for="anthony">Susan B. Anthony</label>
+    </li>
+    <li>
+      <input id="tubman" type="radio" name="historical-figures-2" value="tubman">
+      <label for="tubman">Harriet Tubman</label>
+    </li>
+  </ul>
 
-    <ul class="usa-unstyled-list">
-      <li>
-        <input id="stanton" type="radio" checked name="historical-figures-2" value="stanton">
-        <label for="stanton">Elizabeth Cady Stanton</label>
-      </li>
-      <li>
-        <input id="anthony" type="radio" name="historical-figures-2" value="anthony">
-        <label for="anthony">Susan B. Anthony</label>
-      </li>
-      <li>
-        <input id="tubman" type="radio" name="historical-figures-2" value="tubman">
-        <label for="tubman">Harriet Tubman</label>
-      </li>
-    </ul>
-
-  </fieldset>
-
+</fieldset>

--- a/_includes/code/components/search-bar.html
+++ b/_includes/code/components/search-bar.html
@@ -1,49 +1,47 @@
+<h6>Search big</h6>
 
-  <h6>Search big</h6>
-
-  <div class="usa-grid">
-    <div class="usa-width-one-half">
-      <form class="usa-search usa-search-big">
-        <div role="search">
-          <label class="usa-sr-only" for="search-field-big">Search big</label>
-          <input id="search-field-big" type="search" name="search">
-          <button type="submit">
-            <span class="usa-search-submit-text">Search</span>
-          </button>
-        </div>
-      </form>
-    </div>
+<div class="usa-grid">
+  <div class="usa-width-one-half">
+    <form class="usa-search usa-search-big">
+      <div role="search">
+        <label class="usa-sr-only" for="search-field-big">Search big</label>
+        <input id="search-field-big" type="search" name="search">
+        <button type="submit">
+          <span class="usa-search-submit-text">Search</span>
+        </button>
+      </div>
+    </form>
   </div>
+</div>
 
-  <h6>Search medium</h6>
+<h6>Search medium</h6>
 
-  <div class="usa-grid">
-    <div class="usa-width-one-half">
-      <form class="usa-search">
-        <div role="search">
-          <label class="usa-sr-only" for="search-field">Search medium</label>
-          <input id="search-field" type="search" name="search">
-          <button type="submit">
-            <span class="usa-search-submit-text">Search</span>
-          </button>
-        </div>
-      </form>
-    </div>
+<div class="usa-grid">
+  <div class="usa-width-one-half">
+    <form class="usa-search">
+      <div role="search">
+        <label class="usa-sr-only" for="search-field">Search medium</label>
+        <input id="search-field" type="search" name="search">
+        <button type="submit">
+          <span class="usa-search-submit-text">Search</span>
+        </button>
+      </div>
+    </form>
   </div>
+</div>
 
-  <h6>Search small</h6>
+<h6>Search small</h6>
 
-  <div class="usa-grid">
-    <div class="usa-width-one-half">
-      <form class="usa-search usa-search-small">
-        <div role="search">
-          <label class="usa-sr-only" for="search-field-small">Search small</label>
-          <input id="search-field-small" type="search" name="search">
-          <button type="submit">
-            <span class="usa-sr-only">Search</span>
-          </button>
-        </div>
-      </form>
-    </div>
+<div class="usa-grid">
+  <div class="usa-width-one-half">
+    <form class="usa-search usa-search-small">
+      <div role="search">
+        <label class="usa-sr-only" for="search-field-small">Search small</label>
+        <input id="search-field-small" type="search" name="search">
+        <button type="submit">
+          <span class="usa-sr-only">Search</span>
+        </button>
+      </div>
+    </form>
   </div>
-
+</div>

--- a/_includes/code/components/sidenav.html
+++ b/_includes/code/components/sidenav.html
@@ -1,100 +1,98 @@
+<h6 class="usa-heading-alt">Single level</h6>
 
-  <h6 class="usa-heading-alt">Single level</h6>
+<div class="usa-grid-full">
+  <aside class="usa-width-one-fourth">
+    <ul class="usa-sidenav-list">
+      <li>
+        <a class="usa-current" href="javascript:void(0);">Current page</a>
+      </li>
+      <li>
+        <a href="javascript:void(0);">Parent link</a>
+      </li>
+      <li>
+        <a href="javascript:void(0);">Parent link</a>
+      </li>
+    </ul>
+  </aside>
+</div>
 
-  <div class="usa-grid-full">
-    <aside class="usa-width-one-fourth">
-      <ul class="usa-sidenav-list">
-        <li>
-          <a class="usa-current" href="javascript:void(0);">Current page</a>
-        </li>
-        <li>
-          <a href="javascript:void(0);">Parent link</a>
-        </li>
-        <li>
-          <a href="javascript:void(0);">Parent link</a>
-        </li>
-      </ul>
-    </aside>
-  </div>
+<h6 class="usa-heading-alt">Two levels</h6>
 
-  <h6 class="usa-heading-alt">Two levels</h6>
+<div class="usa-grid-full">
+  <aside class="usa-width-one-fourth">
+    <ul class="usa-sidenav-list">
+      <li>
+        <a href="javascript:void(0);">Parent link</a>
+      </li>
+      <li>
+        <a class="usa-current" href="javascript:void(0);">Current page</a>
+        <ul class="usa-sidenav-sub_list">
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a class="usa-current" href="javascript:void(0);">Child Link</a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a href="javascript:void(0);">Parent link</a>
+      </li>
+    </ul>
+  </aside>
+</div>
 
-  <div class="usa-grid-full">
-    <aside class="usa-width-one-fourth">
-      <ul class="usa-sidenav-list">
-        <li>
-          <a href="javascript:void(0);">Parent link</a>
-        </li>
-        <li>
-          <a class="usa-current" href="javascript:void(0);">Current page</a>
-          <ul class="usa-sidenav-sub_list">
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a class="usa-current" href="javascript:void(0);">Child Link</a>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a href="javascript:void(0);">Parent link</a>
-        </li>
-      </ul>
-    </aside>
-  </div>
+<h6 class="usa-heading-alt">Three levels</h6>
 
-  <h6 class="usa-heading-alt">Three levels</h6>
-
-  <div class="usa-grid-full">
-    <aside class="usa-width-one-fourth">
-      <ul class="usa-sidenav-list">
-        <li>
-          <a href="javascript:void(0);">Parent link</a>
-        </li>
-        <li>
-          <a class="usa-current" href="javascript:void(0);">Current page</a>
-          <ul class="usa-sidenav-sub_list">
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-              <ul class="usa-sidenav-sub_list">
-                <li>
-                  <a href="javascript:void(0);">Grandchild link</a>
-                </li>
-                <li>
-                  <a href="javascript:void(0);">Grandchild link</a>
-                </li>
-                <li>
-                  <a class="usa-current" href="javascript:void(0);">Grandchild link</a>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-            <li>
-              <a href="javascript:void(0);">Child link</a>
-            </li>
-          </ul>
-        </li>
-        <li>
-          <a href="javascript:void(0);">Parent link</a>
-        </li>
-      </ul>
-    </aside>
-  </div>
-
+<div class="usa-grid-full">
+  <aside class="usa-width-one-fourth">
+    <ul class="usa-sidenav-list">
+      <li>
+        <a href="javascript:void(0);">Parent link</a>
+      </li>
+      <li>
+        <a class="usa-current" href="javascript:void(0);">Current page</a>
+        <ul class="usa-sidenav-sub_list">
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+            <ul class="usa-sidenav-sub_list">
+              <li>
+                <a href="javascript:void(0);">Grandchild link</a>
+              </li>
+              <li>
+                <a href="javascript:void(0);">Grandchild link</a>
+              </li>
+              <li>
+                <a class="usa-current" href="javascript:void(0);">Grandchild link</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+          <li>
+            <a href="javascript:void(0);">Child link</a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a href="javascript:void(0);">Parent link</a>
+      </li>
+    </ul>
+  </aside>
+</div>

--- a/_includes/code/components/sign-in-form.html
+++ b/_includes/code/components/sign-in-form.html
@@ -1,26 +1,27 @@
+<form class="usa-form">
+  <fieldset>
+    <legend class="usa-drop_text">Sign in</legend>
+    <span>or <a href="javascript:void(0);">create an account</a></span>
 
-  <form class="usa-form">
-    <fieldset>
-      <legend class="usa-drop_text">Sign in</legend>
-      <span>or <a href="javascript:void(0);">create an account</a></span>
+    <label for="username">Username or email address</label>
+    <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
 
-      <label for="username">Username or email address</label>
-      <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password">
+    <p class="usa-form-note">
+      <a title="Show password" href="javascript:void(0);"
+          class="usa-show_password"
+          aria-controls="password">
+        Show password</a>
+    </p>
 
-      <label for="password">Password</label>
-      <input id="password" name="password" type="password">
-      <p class="usa-form-note">
-        <a title="Show password" href="javascript:void(0);"
-            class="usa-show_password"
-            aria-controls="password">
-          Show password</a>
-      </p>
+    <input type="submit" value="Sign in">
 
-      <input type="submit" value="Sign in" />
-      <p><a href="javascript:void(0);" title="Forgot username">
-        Forgot username?</a></p>
-      <p><a href="javascript:void(0);" title="Forgot password">
-        Forgot password?</a></p>
-    </fieldset>
-  </form>
+    <p><a href="javascript:void(0);" title="Forgot username">
+      Forgot username?</a></p>
+    <p><a href="javascript:void(0);" title="Forgot password">
+      Forgot password?</a></p>
+
+  </fieldset>
+</form>
 

--- a/_includes/code/components/sign-in-form.html
+++ b/_includes/code/components/sign-in-form.html
@@ -3,15 +3,15 @@
     <legend class="usa-drop_text">Sign in</legend>
     <span>or <a href="javascript:void(0);">create an account</a></span>
 
-    <label for="username">Username or email address</label>
-    <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
+    <label for="sign-in-username">Username or email address</label>
+    <input id="sign-in-username" name="username" type="text" autocapitalize="off" autocorrect="off">
 
-    <label for="password">Password</label>
-    <input id="password" name="password" type="password">
+    <label for="sign-in-password">Password</label>
+    <input id="sign-in-password" name="password" type="password">
     <p class="usa-form-note">
       <a title="Show password" href="javascript:void(0);"
           class="usa-show_password"
-          aria-controls="password">
+          aria-controls="sign-in-password">
         Show password</a>
     </p>
 

--- a/_includes/code/components/sign-in-form.html
+++ b/_includes/code/components/sign-in-form.html
@@ -24,4 +24,3 @@
 
   </fieldset>
 </form>
-

--- a/_includes/code/components/tables.html
+++ b/_includes/code/components/tables.html
@@ -1,69 +1,67 @@
+<h6>Bordered Table</h6>
 
-  <h6>Bordered Table</h6>
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Document title</th>
+      <th scope="col">Description</th>
+      <th scope="col">Year</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Declaration of Independence</th>
+      <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
+      <td>1776</td>
+    </tr>
+    <tr>
+      <th scope="row">Bill of Rights</th>
+      <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
+      <td>1791</td>
+    </tr>
+    <tr>
+      <th scope="row">Declaration of Sentiments</th>
+      <td>A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
+      <td>1848</td>
+    </tr>
+    <tr>
+      <th scope="row">Emancipation Proclamation</th>
+      <td>An executive order granting freedom to slaves in designated southern states.</td>
+      <td>1863</td>
+    </tr>
+  </tbody>
+</table>
 
-  <table>
-    <thead>
-      <tr>
-        <th scope="col">Document title</th>
-        <th scope="col">Description</th>
-        <th scope="col">Year</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">Declaration of Independence</th>
-        <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
-        <td>1776</td>
-      </tr>
-      <tr>
-        <th scope="row">Bill of Rights</th>
-        <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
-        <td>1791</td>
-      </tr>
-      <tr>
-        <th scope="row">Declaration of Sentiments</th>
-        <td>A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
-        <td>1848</td>
-      </tr>
-      <tr>
-        <th scope="row">Emancipation Proclamation</th>
-        <td>An executive order granting freedom to slaves in designated southern states.</td>
-        <td>1863</td>
-      </tr>
-    </tbody>
-  </table>
+<h6>Borderless Table</h6>
 
-  <h6>Borderless Table</h6>
-
-  <table class="usa-table-borderless">
-    <thead>
-      <tr>
-        <th scope="col">Document Title</th>
-        <th scope="col">Description</th>
-        <th scope="col">Year</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">Declaration of Independence</th>
-        <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
-        <td>1776</td>
-      </tr>
-      <tr>
-        <th scope="row">Bill of Rights</th>
-        <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
-        <td>1791</td>
-      </tr>
-      <tr>
-        <th scope="row">Declaration of Sentiments</th>
-        <td>MadeA document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
-        <td>1848</td>
-      </tr>
-      <tr>
-        <th scope="row">Emancipation Proclamation</th>
-        <td>An executive order granting freedom to slaves in designated southern states.</td>
-        <td>1863</td>
-      </tr>
-    </tbody>
-  </table>
-
+<table class="usa-table-borderless">
+  <thead>
+    <tr>
+      <th scope="col">Document Title</th>
+      <th scope="col">Description</th>
+      <th scope="col">Year</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Declaration of Independence</th>
+      <td>Statement adopted by the Continental Congress declaring independence from the British Empire.</td>
+      <td>1776</td>
+    </tr>
+    <tr>
+      <th scope="row">Bill of Rights</th>
+      <td>The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.</td>
+      <td>1791</td>
+    </tr>
+    <tr>
+      <th scope="row">Declaration of Sentiments</th>
+      <td>MadeA document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.</td>
+      <td>1848</td>
+    </tr>
+    <tr>
+      <th scope="row">Emancipation Proclamation</th>
+      <td>An executive order granting freedom to slaves in designated southern states.</td>
+      <td>1863</td>
+    </tr>
+  </tbody>
+</table>

--- a/_includes/code/components/template-docs.html
+++ b/_includes/code/components/template-docs.html
@@ -1,208 +1,207 @@
-
-  <!doctype html>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Page title</title>
-      <!-- Update the link path to where your stylesheet file is located. For example: /path/to/your/assets/css/lib/uswds.min.css -->
-      <link rel="stylesheet" href="{{ "/assets/css/styleguide.css" | prepend: site.baseurl }}">
-    </head>
-    <body class="layout-demo">
-    <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-    <header class="usa-header usa-header-basic" role="banner">
-      <!-- Gov banner BEGIN -->
-      <div class="usa-banner">
-        <div class="usa-accordion">
-          <header class="usa-banner-header">
-            <div class="usa-grid usa-banner-inner">
-            <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
-            <p>An official website of the United States government</p>
-            <button class="usa-accordion-button usa-banner-button"
-              aria-expanded="false" aria-controls="gov-banner">
-              <span class="usa-banner-button-text">Here's how you know</span>
-            </button>
-            </div>
-          </header>
-          <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-            <div class="usa-banner-guidance-gov usa-width-one-half">
-              <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-              <div class="usa-media_block-body">
-                <p>
-                  <strong>The .gov means it’s official.</strong>
-                  <br>
-                  Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-                </p>
-              </div>
-            </div>
-            <div class="usa-banner-guidance-ssl usa-width-one-half">
-              <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-              <div class="usa-media_block-body">
-                <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <!-- Gov banner END -->
-      <div class="usa-nav-container">
-        <div class="usa-navbar">
-          <button class="usa-menu-btn">Menu</button>
-          <div class="usa-logo" id="logo">
-            <em class="usa-logo-text">
-              <a href="#" accesskey="1" title="Home" aria-label="Home">Federal <br>Agency Name</a>
-            </em>
-          </div>
-        </div>
-        <nav role="navigation" class="usa-nav">
-          <button class="usa-nav-close">
-            <img src="{{ site.baseurl }}/assets/img/close.svg" alt="close">
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page title</title>
+    <!-- Update the link path to where your stylesheet file is located. For example: /path/to/your/assets/css/lib/uswds.min.css -->
+    <link rel="stylesheet" href="{{ "/assets/css/styleguide.css" | prepend: site.baseurl }}">
+  </head>
+  <body class="layout-demo">
+  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  <header class="usa-header usa-header-basic" role="banner">
+    <!-- Gov banner BEGIN -->
+    <div class="usa-banner">
+      <div class="usa-accordion">
+        <header class="usa-banner-header">
+          <div class="usa-grid usa-banner-inner">
+          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+          <button class="usa-accordion-button usa-banner-button"
+            aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner-button-text">Here's how you know</span>
           </button>
-          <ul class="usa-nav-primary usa-accordion">
-            <li>
-              <button class="
-              usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
-                <span>Section title</span>
-              </button>
-              <ul id="side-nav-1" class="usa-nav-submenu">
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
-                <span>Simple terms</span>
-              </button>
-              <ul id="sidenav-2" class="usa-nav-submenu">
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a class="usa-nav-link" href="#">
-                <span>Distinct from each other</span>
-              </a>
-            </li>
-          </ul>
-          <form class="usa-search usa-search-small">
-            <div role="search">
-              <label class="usa-sr-only" for="search-field-small">Search small</label>
-              <input id="search-field-small" type="search" name="search">
-              <button type="submit">
-                <span class="usa-sr-only">Search</span>
-              </button>
+          </div>
+        </header>
+        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+          <div class="usa-banner-guidance-gov usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+            <div class="usa-media_block-body">
+              <p>
+                <strong>The .gov means it’s official.</strong>
+                <br>
+                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+              </p>
             </div>
-          </form>
-        </nav>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+            <div class="usa-media_block-body">
+              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+            </div>
+          </div>
+        </div>
       </div>
-    </header>
-    <div class="usa-overlay"></div>
-    <main class="usa-grid usa-section usa-content usa-layout-docs" id="main-content">
-      <aside class="usa-width-one-fourth usa-layout-docs-sidenav">
-        <ul class="usa-sidenav-list">
+    </div>
+    <!-- Gov banner END -->
+    <div class="usa-nav-container">
+      <div class="usa-navbar">
+        <button class="usa-menu-btn">Menu</button>
+        <div class="usa-logo" id="logo">
+          <em class="usa-logo-text">
+            <a href="#" accesskey="1" title="Home" aria-label="Home">Federal <br>Agency Name</a>
+          </em>
+        </div>
+      </div>
+      <nav role="navigation" class="usa-nav">
+        <button class="usa-nav-close">
+          <img src="{{ site.baseurl }}/assets/img/close.svg" alt="close">
+        </button>
+        <ul class="usa-nav-primary usa-accordion">
           <li>
-            <a href="javascript:void(0);">Page title</a>
-          </li>
-          <li>
-            <a class="usa-current" href="javascript:void(0);">Page heading (h1)</a>
-            <ul class="usa-sidenav-sub_list">
+            <button class="
+            usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
+              <span>Section title</span>
+            </button>
+            <ul id="side-nav-1" class="usa-nav-submenu">
               <li>
-                <a href="#section-heading-h2">Section heading (h2)</a>
+                <a href="#">Page title</a>
               </li>
               <li>
-                <a href="#section-heading-h3">Subsection heading (h3)</a>
+                <a href="#">Page title</a>
               </li>
               <li>
-                <a href="#section-heading-h4">Subsection heading (h4)</a>
+                <a href="#">Page title</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="javascript:void(0);">Page title</a>
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
+              <span>Simple terms</span>
+            </button>
+            <ul id="sidenav-2" class="usa-nav-submenu">
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="usa-nav-link" href="#">
+              <span>Distinct from each other</span>
+            </a>
           </li>
         </ul>
-      </aside>
-      <div class="usa-width-three-fourths usa-layout-docs-main_content">
-        <h1>Page heading (h1)</h1>
-        <p class="usa-font-lead">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
-        <h2 id="section-heading-h2">Section heading (h2)</h2>
-        <p>These headings introduce, respectively, sections and subsections within your body copy. As you create these headings, follow the same guidelines that you use when writing section headings: Be succinct, descriptive, and precise.</p>
-        <h3 id="section-heading-h3">Subsection heading (h3)</h3>
-        <p>The particulars of your body copy will be determined by the topic of your page. Regardless of topic, it’s a good practice to follow the inverted pyramid structure when writing copy: Begin with the information that’s most important to your users and then present information of less importance.</p>
-        <p>Keep each section and subsection focused — a good approach is to include one theme (topic) per section.</p>
-        <h4 id="section-heading-h4">Subsection heading (h4)</h4>
-        <p>Use the side navigation menu to help your users quickly skip to different sections of your page. The menu is best suited to displaying a hierarchy with one to three levels and, as we mentioned, to display the sub-navigation of a given page.</p>
-        <p>Read the full documentation on our side navigation on the <a href="{{ site.baseurl }}/sidenav/">component page</a>.</p>
+        <form class="usa-search usa-search-small">
+          <div role="search">
+            <label class="usa-sr-only" for="search-field-small">Search small</label>
+            <input id="search-field-small" type="search" name="search">
+            <button type="submit">
+              <span class="usa-sr-only">Search</span>
+            </button>
+          </div>
+        </form>
+      </nav>
+    </div>
+  </header>
+  <div class="usa-overlay"></div>
+  <main class="usa-grid usa-section usa-content usa-layout-docs" id="main-content">
+    <aside class="usa-width-one-fourth usa-layout-docs-sidenav">
+      <ul class="usa-sidenav-list">
+        <li>
+          <a href="javascript:void(0);">Page title</a>
+        </li>
+        <li>
+          <a class="usa-current" href="javascript:void(0);">Page heading (h1)</a>
+          <ul class="usa-sidenav-sub_list">
+            <li>
+              <a href="#section-heading-h2">Section heading (h2)</a>
+            </li>
+            <li>
+              <a href="#section-heading-h3">Subsection heading (h3)</a>
+            </li>
+            <li>
+              <a href="#section-heading-h4">Subsection heading (h4)</a>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a href="javascript:void(0);">Page title</a>
+        </li>
+      </ul>
+    </aside>
+    <div class="usa-width-three-fourths usa-layout-docs-main_content">
+      <h1>Page heading (h1)</h1>
+      <p class="usa-font-lead">The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct.</p>
+      <h2 id="section-heading-h2">Section heading (h2)</h2>
+      <p>These headings introduce, respectively, sections and subsections within your body copy. As you create these headings, follow the same guidelines that you use when writing section headings: Be succinct, descriptive, and precise.</p>
+      <h3 id="section-heading-h3">Subsection heading (h3)</h3>
+      <p>The particulars of your body copy will be determined by the topic of your page. Regardless of topic, it’s a good practice to follow the inverted pyramid structure when writing copy: Begin with the information that’s most important to your users and then present information of less importance.</p>
+      <p>Keep each section and subsection focused — a good approach is to include one theme (topic) per section.</p>
+      <h4 id="section-heading-h4">Subsection heading (h4)</h4>
+      <p>Use the side navigation menu to help your users quickly skip to different sections of your page. The menu is best suited to displaying a hierarchy with one to three levels and, as we mentioned, to display the sub-navigation of a given page.</p>
+      <p>Read the full documentation on our side navigation on the <a href="{{ site.baseurl }}/sidenav/">component page</a>.</p>
+    </div>
+  </main>
+  <footer class="usa-footer usa-footer-medium" role="contentinfo">
+    <div class="usa-grid usa-footer-return-to-top">
+      <a href="#">Return to top</a>
+    </div>
+    <div class="usa-footer-primary-section">
+      <div class="usa-grid-full">
+        <nav class="usa-footer-nav">
+          <ul class="usa-unstyled-list">
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+            </li>
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Permanently relevant</a>
+            </li>
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Easy to understand</a>
+            </li>
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Site policies (example)</a>
+            </li>
+          </ul>
+        </nav>
       </div>
-    </main>
-    <footer class="usa-footer usa-footer-medium" role="contentinfo">
-      <div class="usa-grid usa-footer-return-to-top">
-        <a href="#">Return to top</a>
-      </div>
-      <div class="usa-footer-primary-section">
-        <div class="usa-grid-full">
-          <nav class="usa-footer-nav">
-            <ul class="usa-unstyled-list">
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-              </li>
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Permanently relevant</a>
-              </li>
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Easy to understand</a>
-              </li>
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Site policies (example)</a>
-              </li>
-            </ul>
-          </nav>
-        </div>
-      </div>
+    </div>
 
-      <div class="usa-footer-secondary_section">
-        <div class="usa-grid">
-          <div class="usa-footer-logo usa-width-one-half">
-            <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
-            <h3 class="usa-footer-logo-heading">Name of Agency</h3>
-          </div>
-          <div class="usa-footer-contact-links usa-width-one-half">
-            <a class="usa-link-facebook" href="javascript:void(0);">
-              <span>Facebook</span>
-            </a>
-            <a class="usa-link-twitter" href="javascript:void(0);">
-              <span>Twitter</span>
-            </a>
-            <a class="usa-link-youtube" href="javascript:void(0);">
-              <span>YouTube</span>
-            </a>
-            <a class="usa-link-rss" href="javascript:void(0);">
-              <span>RSS</span>
-            </a>
-            <address>
-              <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-              <p>(800) CALL-GOVT</p>
-              <a href="mailto:info@agency.gov">info@agency.gov</a>
-            </address>
-          </div>
+    <div class="usa-footer-secondary_section">
+      <div class="usa-grid">
+        <div class="usa-footer-logo usa-width-one-half">
+          <img class="usa-footer-logo-img" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
+          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+        </div>
+        <div class="usa-footer-contact-links usa-width-one-half">
+          <a class="usa-link-facebook" href="javascript:void(0);">
+            <span>Facebook</span>
+          </a>
+          <a class="usa-link-twitter" href="javascript:void(0);">
+            <span>Twitter</span>
+          </a>
+          <a class="usa-link-youtube" href="javascript:void(0);">
+            <span>YouTube</span>
+          </a>
+          <a class="usa-link-rss" href="javascript:void(0);">
+            <span>RSS</span>
+          </a>
+          <address>
+            <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
+            <p>(800) CALL-GOVT</p>
+            <a href="mailto:info@agency.gov">info@agency.gov</a>
+          </address>
         </div>
       </div>
-    </footer>
-    <!-- Update the link path to where your JavaScript file is located. For example: /path/to/your/assets/js/lib/uswds.min.js -->
-    <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
-    </body>
-  </html>
+    </div>
+  </footer>
+  <!-- Update the link path to where your JavaScript file is located. For example: /path/to/your/assets/js/lib/uswds.min.js -->
+  <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
+  </body>
+</html>

--- a/_includes/code/components/template-landing.html
+++ b/_includes/code/components/template-landing.html
@@ -1,260 +1,259 @@
-
-  <!doctype html>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>Page title</title>
-      <!-- Update the link path to where your stylesheet file is located. For example: /path/to/your/assets/css/lib/uswds.min.css -->
-      <link rel="stylesheet" href="{{ "/assets/css/styleguide.css" | prepend: site.baseurl }}">
-    </head>
-    <body class="layout-demo">
-    <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-    <header class="usa-header usa-header-extended" role="banner">
-      <!-- Gov banner BEGIN -->
-      <div class="usa-banner">
-        <div class="usa-accordion">
-          <header class="usa-banner-header">
-            <div class="usa-grid usa-banner-inner">
-            <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
-            <p>An official website of the United States government</p>
-            <button class="usa-accordion-button usa-banner-button"
-              aria-expanded="false" aria-controls="gov-banner">
-              <span class="usa-banner-button-text">Here's how you know</span>
-            </button>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page title</title>
+    <!-- Update the link path to where your stylesheet file is located. For example: /path/to/your/assets/css/lib/uswds.min.css -->
+    <link rel="stylesheet" href="{{ "/assets/css/styleguide.css" | prepend: site.baseurl }}">
+  </head>
+  <body class="layout-demo">
+  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  <header class="usa-header usa-header-extended" role="banner">
+    <!-- Gov banner BEGIN -->
+    <div class="usa-banner">
+      <div class="usa-accordion">
+        <header class="usa-banner-header">
+          <div class="usa-grid usa-banner-inner">
+          <img src="{{ site.baseurl }}/assets/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+          <button class="usa-accordion-button usa-banner-button"
+            aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner-button-text">Here's how you know</span>
+          </button>
+          </div>
+        </header>
+        <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+          <div class="usa-banner-guidance-gov usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
+            <div class="usa-media_block-body">
+              <p>
+                <strong>The .gov means it’s official.</strong>
+                <br>
+                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+              </p>
             </div>
-          </header>
-          <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-            <div class="usa-banner-guidance-gov usa-width-one-half">
-              <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-dot-gov.svg" alt="Dot gov">
-              <div class="usa-media_block-body">
-                <p>
-                  <strong>The .gov means it’s official.</strong>
-                  <br>
-                  Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
-                </p>
-              </div>
-            </div>
-            <div class="usa-banner-guidance-ssl usa-width-one-half">
-              <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
-              <div class="usa-media_block-body">
-                <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
-              </div>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/img/icon-https.svg" alt="SSL">
+            <div class="usa-media_block-body">
+              <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
             </div>
           </div>
         </div>
       </div>
-      <!-- Gov banner END -->
-      <div class="usa-navbar">
-        <button class="usa-menu-btn">Menu</button>
-        <div class="usa-logo" id="logo">
-          <em class="usa-logo-text">
-            <a href="#" accesskey="1" title="Home" aria-label="Home">Federal Agency Name</a>
-          </em>
-        </div>
+    </div>
+    <!-- Gov banner END -->
+    <div class="usa-navbar">
+      <button class="usa-menu-btn">Menu</button>
+      <div class="usa-logo" id="logo">
+        <em class="usa-logo-text">
+          <a href="#" accesskey="1" title="Home" aria-label="Home">Federal Agency Name</a>
+        </em>
       </div>
-      <nav role="navigation" class="usa-nav">
-        <div class="usa-nav-inner">
-          <button class="usa-nav-close">
-            <img src="{{ site.baseurl }}/assets/img/close.svg" alt="close">
-          </button>
-          <ul class="usa-nav-primary usa-accordion">
-            <li>
-              <button class="
-              usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
-                <span>Section title</span>
+    </div>
+    <nav role="navigation" class="usa-nav">
+      <div class="usa-nav-inner">
+        <button class="usa-nav-close">
+          <img src="{{ site.baseurl }}/assets/img/close.svg" alt="close">
+        </button>
+        <ul class="usa-nav-primary usa-accordion">
+          <li>
+            <button class="
+            usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
+              <span>Section title</span>
+            </button>
+            <ul id="side-nav-1" class="usa-nav-submenu">
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
+              <span>Simple terms</span>
+            </button>
+            <ul id="sidenav-2" class="usa-nav-submenu">
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a class="usa-nav-link" href="#">
+              <span>Distinct from each other</span>
+            </a>
+          </li>
+          <li>
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
+              <span>More details in sub-menus</span>
+            </button>
+            <ul id="sidenav-3" class="usa-nav-submenu">
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+              <li>
+                <a href="#">Page title</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <div class="usa-nav-secondary">
+          <form class="usa-search usa-search-small js-search-form">
+            <div role="search">
+              <label class="usa-sr-only" for="search-field-small">Search small</label>
+              <input id="search-field-small" type="search" name="search">
+              <button type="submit">
+                <span class="usa-sr-only">Search</span>
               </button>
-              <ul id="side-nav-1" class="usa-nav-submenu">
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-              </ul>
+            </div>
+          </form>
+          <ul class="usa-unstyled-list usa-nav-secondary-links">
+            <li class="js-search-button-container">
+              <button class="usa-header-search-button js-search-button">Search</button>
             </li>
             <li>
-              <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
-                <span>Simple terms</span>
-              </button>
-              <ul id="sidenav-2" class="usa-nav-submenu">
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-              </ul>
+              <a href="#">Secondary priority link</a>
             </li>
             <li>
-              <a class="usa-nav-link" href="#">
-                <span>Distinct from each other</span>
-              </a>
-            </li>
-            <li>
-              <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
-                <span>More details in sub-menus</span>
-              </button>
-              <ul id="sidenav-3" class="usa-nav-submenu">
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-                <li>
-                  <a href="#">Page title</a>
-                </li>
-              </ul>
+              <a href="#">Easy to comprehend</a>
             </li>
           </ul>
-          <div class="usa-nav-secondary">
-            <form class="usa-search usa-search-small js-search-form">
-              <div role="search">
-                <label class="usa-sr-only" for="search-field-small">Search small</label>
-                <input id="search-field-small" type="search" name="search">
-                <button type="submit">
-                  <span class="usa-sr-only">Search</span>
-                </button>
-              </div>
-            </form>
-            <ul class="usa-unstyled-list usa-nav-secondary-links">
-              <li class="js-search-button-container">
-                <button class="usa-header-search-button js-search-button">Search</button>
-              </li>
-              <li>
-                <a href="#">Secondary priority link</a>
-              </li>
-              <li>
-                <a href="#">Easy to comprehend</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-    </header>
-    <div class="usa-overlay"></div>
-    <main id="main-content">
-      <section class="usa-hero">
-        <div class="usa-grid">
-          <div class="usa-hero-callout usa-section-dark">
-            <h2><span class="usa-hero-callout-alt">Hero callout:</span> Call attention to a current priority</h2>
-            <a class="usa-hero-link" href="#">Link to more about that priority</a>
-            <a class="usa-button usa-button-big usa-button-secondary" href="#">Learn about what we do</a>
-          </div>
-        </div>
-      </section>
-      <section class="usa-grid usa-section">
-        <div class="usa-width-one-third">
-          <h2>A tagline highlights your approach.</h2>
-        </div>
-        <div class="usa-width-two-thirds">
-          <p>The tagline should inspire confidence and interest, focusing on the value that your overall approach offers to your audience. Use a heading typeface and keep your tagline to just a few words, and don’t confuse or mystify.</p>
-          <p>Use the right side of the grid to explain the tagline a bit more. What are your goals? How do you do your work? Write in the present tense, and stay brief here. People who are interested can find details on internal pages.</p>
-        </div>
-      </section>
-      <section class="usa-section usa-section-dark usa-graphic_list">
-        <div class="usa-grid usa-graphic_list-row">
-          <div class="usa-width-one-half usa-media_block">
-            <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
-            <div class="usa-media_block-body">
-              <h3>Graphic headings can vary.</h3>
-              <p>Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.</p>
-            </div>
-          </div>
-          <div class="usa-width-one-half usa-media_block">
-            <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
-            <div class="usa-media_block-body">
-              <h3>Stick to 6 or fewer words.</h3>
-              <p>Keep body text to about 30. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.</p>
-            </div>
-          </div>
-        </div>
-        <div class="usa-grid usa-graphic_list-row">
-          <div class="usa-width-one-half usa-media_block">
-            <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
-            <div class="usa-media_block-body">
-              <h3>Never highlight anything without a goal.</h3>
-              <p>For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.</p>
-            </div>
-          </div>
-          <div class="usa-width-one-half usa-media_block">
-            <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
-            <div class="usa-media_block-body">
-              <h3>Could also have 2 or 6.</h3>
-              <p>In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.</p>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section class="usa-section">
-        <div class="usa-grid">
-          <h2>Section heading</h2>
-          <p class="usa-font-lead">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
-          <a class="usa-button usa-button-big" href="#">Call to action</a>
-        </div>
-      </section>
-    </main>
-    <footer class="usa-footer usa-footer-medium" role="contentinfo">
-      <div class="usa-grid usa-footer-return-to-top">
-        <a href="#">Return to top</a>
-      </div>
-      <div class="usa-footer-primary-section">
-        <div class="usa-grid-full">
-          <nav class="usa-footer-nav">
-            <ul class="usa-unstyled-list">
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
-              </li>
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Permanently relevant</a>
-              </li>
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Easy to understand</a>
-              </li>
-              <li class="usa-width-one-fourth usa-footer-primary-content">
-                <a class="usa-footer-primary-link" href="javascript:void(0);">Site policies (example)</a>
-              </li>
-            </ul>
-          </nav>
         </div>
       </div>
+    </nav>
+  </header>
+  <div class="usa-overlay"></div>
+  <main id="main-content">
+    <section class="usa-hero">
+      <div class="usa-grid">
+        <div class="usa-hero-callout usa-section-dark">
+          <h2><span class="usa-hero-callout-alt">Hero callout:</span> Call attention to a current priority</h2>
+          <a class="usa-hero-link" href="#">Link to more about that priority</a>
+          <a class="usa-button usa-button-big usa-button-secondary" href="#">Learn about what we do</a>
+        </div>
+      </div>
+    </section>
+    <section class="usa-grid usa-section">
+      <div class="usa-width-one-third">
+        <h2>A tagline highlights your approach.</h2>
+      </div>
+      <div class="usa-width-two-thirds">
+        <p>The tagline should inspire confidence and interest, focusing on the value that your overall approach offers to your audience. Use a heading typeface and keep your tagline to just a few words, and don’t confuse or mystify.</p>
+        <p>Use the right side of the grid to explain the tagline a bit more. What are your goals? How do you do your work? Write in the present tense, and stay brief here. People who are interested can find details on internal pages.</p>
+      </div>
+    </section>
+    <section class="usa-section usa-section-dark usa-graphic_list">
+      <div class="usa-grid usa-graphic_list-row">
+        <div class="usa-width-one-half usa-media_block">
+          <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
+          <div class="usa-media_block-body">
+            <h3>Graphic headings can vary.</h3>
+            <p>Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.</p>
+          </div>
+        </div>
+        <div class="usa-width-one-half usa-media_block">
+          <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
+          <div class="usa-media_block-body">
+            <h3>Stick to 6 or fewer words.</h3>
+            <p>Keep body text to about 30. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.</p>
+          </div>
+        </div>
+      </div>
+      <div class="usa-grid usa-graphic_list-row">
+        <div class="usa-width-one-half usa-media_block">
+          <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
+          <div class="usa-media_block-body">
+            <h3>Never highlight anything without a goal.</h3>
+            <p>For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.</p>
+          </div>
+        </div>
+        <div class="usa-width-one-half usa-media_block">
+          <img class="usa-media_block-img"  src="{{ site.baseurl }}/assets/img/circle-124.png" alt="Alt text">
+          <div class="usa-media_block-body">
+            <h3>Could also have 2 or 6.</h3>
+            <p>In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="usa-section">
+      <div class="usa-grid">
+        <h2>Section heading</h2>
+        <p class="usa-font-lead">Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
+        <a class="usa-button usa-button-big" href="#">Call to action</a>
+      </div>
+    </section>
+  </main>
+  <footer class="usa-footer usa-footer-medium" role="contentinfo">
+    <div class="usa-grid usa-footer-return-to-top">
+      <a href="#">Return to top</a>
+    </div>
+    <div class="usa-footer-primary-section">
+      <div class="usa-grid-full">
+        <nav class="usa-footer-nav">
+          <ul class="usa-unstyled-list">
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Primary link</a>
+            </li>
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Permanently relevant</a>
+            </li>
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Easy to understand</a>
+            </li>
+            <li class="usa-width-one-fourth usa-footer-primary-content">
+              <a class="usa-footer-primary-link" href="javascript:void(0);">Site policies (example)</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
 
-      <div class="usa-footer-secondary_section">
-        <div class="usa-grid">
-          <div class="usa-footer-logo usa-width-one-half">
-            <img class="usa-footer-circle-124" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
-            <h3 class="usa-footer-logo-heading">Name of Agency</h3>
-          </div>
-          <div class="usa-footer-contact-links usa-width-one-half">
-            <a class="usa-link-facebook" href="javascript:void(0);">
-              <span>Facebook</span>
-            </a>
-            <a class="usa-link-twitter" href="javascript:void(0);">
-              <span>Twitter</span>
-            </a>
-            <a class="usa-link-youtube" href="javascript:void(0);">
-              <span>YouTube</span>
-            </a>
-            <a class="usa-link-rss" href="javascript:void(0);">
-              <span>RSS</span>
-            </a>
-            <address>
-              <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
-              <p>(800) CALL-GOVT</p>
-              <a href="mailto:info@agency.gov">info@agency.gov</a>
-            </address>
-          </div>
+    <div class="usa-footer-secondary_section">
+      <div class="usa-grid">
+        <div class="usa-footer-logo usa-width-one-half">
+          <img class="usa-footer-circle-124" src="{{ site.baseurl }}/assets/img/logo-img.png" alt="Logo image">
+          <h3 class="usa-footer-logo-heading">Name of Agency</h3>
+        </div>
+        <div class="usa-footer-contact-links usa-width-one-half">
+          <a class="usa-link-facebook" href="javascript:void(0);">
+            <span>Facebook</span>
+          </a>
+          <a class="usa-link-twitter" href="javascript:void(0);">
+            <span>Twitter</span>
+          </a>
+          <a class="usa-link-youtube" href="javascript:void(0);">
+            <span>YouTube</span>
+          </a>
+          <a class="usa-link-rss" href="javascript:void(0);">
+            <span>RSS</span>
+          </a>
+          <address>
+            <h3 class="usa-footer-contact-heading">Agency Contact Center</h3>
+            <p>(800) CALL-GOVT</p>
+            <a href="mailto:info@agency.gov">info@agency.gov</a>
+          </address>
         </div>
       </div>
-    </footer>
-    <!-- Update the link path to where your JavaScript file is located. For example: /path/to/your/assets/js/lib/uswds.min.js -->
-    <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
-    </body>
-  </html>
+    </div>
+  </footer>
+  <!-- Update the link path to where your JavaScript file is located. For example: /path/to/your/assets/js/lib/uswds.min.js -->
+  <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
+  </body>
+</html>

--- a/_includes/code/components/text-input.html
+++ b/_includes/code/components/text-input.html
@@ -1,19 +1,17 @@
+<label for="input-type-text">Text input label</label>
+<input id="input-type-text" name="input-type-text" type="text">
 
-  <label for="input-type-text">Text input label</label>
-  <input id="input-type-text" name="input-type-text" type="text">
+<label for="input-focus">Text input focused</label>
+<input class="usa-input-focus" id="input-focus" name="input-focus" type="text">
 
-  <label for="input-focus">Text input focused</label>
-  <input class="usa-input-focus" id="input-focus" name="input-focus" type="text">
+<div class="usa-input-error">
+  <label class="usa-input-error-label" for="input-error">Text input error</label>
+  <span class="usa-input-error-message" id="input-error-message" role="alert">Helpful error message</span>
+  <input id="input-error" name="input-error" type="text" aria-describedby="input-error-message">
+</div>
 
-  <div class="usa-input-error">
-    <label class="usa-input-error-label" for="input-error">Text input error</label>
-    <span class="usa-input-error-message" id="input-error-message" role="alert">Helpful error message</span>
-    <input id="input-error" name="input-error" type="text" aria-describedby="input-error-message">
-  </div>
+<label for="input-success">Text input success</label>
+<input class="usa-input-success" id="input-success" name="input-success" type="text">
 
-  <label for="input-success">Text input success</label>
-  <input class="usa-input-success" id="input-success" name="input-success" type="text">
-
-  <label for="input-type-textarea">Text area label</label>
-  <textarea id="input-type-textarea" name="input-type-textarea"></textarea>
-
+<label for="input-type-textarea">Text area label</label>
+<textarea id="input-type-textarea" name="input-type-textarea"></textarea>

--- a/_includes/code/components/typesetting.html
+++ b/_includes/code/components/typesetting.html
@@ -1,25 +1,23 @@
+<h6 class="usa-heading-alt">Alignment</h6>
+<div class="alignment-example">
+  <h4>The Grand Canyon</h4>
+  <p>Grand Canyon National Park is the United States' 15th oldest national park. Named a UNESCO World Heritage Site in 1979, the park is located in Arizona.</p>
+</div>
 
-  <h6 class="usa-heading-alt">Alignment</h6>
-  <div class="alignment-example">
-    <h4>The Grand Canyon</h4>
-    <p>Grand Canyon National Park is the United States' 15th oldest national park. Named a UNESCO World Heritage Site in 1979, the park is located in Arizona.</p>
-  </div>
+<h6 class="usa-heading-alt">Line length - Desktop</h6>
+<div class="usa-line-length-example">
+  <p>Yosemite National Park is set within California’s Sierra Nevada mountains. It’s famed for its giant, ancient sequoias, and for Tunnel View, the iconic vista of towering Bridalveil Fall and the granite cliffs of El Capitan and Half Dome.</p>
+  <p class="help-text">75 characters max on desktop</p>
+</div>
 
-  <h6 class="usa-heading-alt">Line length - Desktop</h6>
-  <div class="usa-line-length-example">
-    <p>Yosemite National Park is set within California’s Sierra Nevada mountains. It’s famed for its giant, ancient sequoias, and for Tunnel View, the iconic vista of towering Bridalveil Fall and the granite cliffs of El Capitan and Half Dome.</p>
-    <p class="help-text">75 characters max on desktop</p>
-  </div>
-
-  <h6 class="usa-heading-alt">Spacing</h6>
-  <h1>Section heading</h1>
-  <p class="usa-font-lead">Great Smoky Mountains National Park straddles the border of North Carolina and Tennessee.</p>
-  <h2>Section heading</h2>
-  <h3>Section of the page</h3>
-  <p>The sprawling landscape encompasses lush forests and an abundance of wildflowers that bloom year-round. Streams, rivers and waterfalls appear along hiking routes that include a segment of the Appalachian Trail.</p>
-  <h4>Subsection of the page</h4>
-  <p>World renowned for its diversity of plant and animal life, the beauty of its ancient mountains, and the quality of its remnants of Southern Appalachian mountain culture, this is America's most visited national park.</p>
-  <p>Right now scientists think that we only know about 17 percent of the plants and animals that live in the park, or about 17,000 species of a probable 100,000 different organisms.</p>
-  <h5>Subsection of the page</h5>
-  <p>Entrance to Great Smoky Mountains National Park is free. The park is one of the few national parks where no entrance fees are charged.</p>
-
+<h6 class="usa-heading-alt">Spacing</h6>
+<h1>Section heading</h1>
+<p class="usa-font-lead">Great Smoky Mountains National Park straddles the border of North Carolina and Tennessee.</p>
+<h2>Section heading</h2>
+<h3>Section of the page</h3>
+<p>The sprawling landscape encompasses lush forests and an abundance of wildflowers that bloom year-round. Streams, rivers and waterfalls appear along hiking routes that include a segment of the Appalachian Trail.</p>
+<h4>Subsection of the page</h4>
+<p>World renowned for its diversity of plant and animal life, the beauty of its ancient mountains, and the quality of its remnants of Southern Appalachian mountain culture, this is America's most visited national park.</p>
+<p>Right now scientists think that we only know about 17 percent of the plants and animals that live in the park, or about 17,000 species of a probable 100,000 different organisms.</p>
+<h5>Subsection of the page</h5>
+<p>Entrance to Great Smoky Mountains National Park is free. The park is one of the few national parks where no entrance fees are charged.</p>

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -946,7 +946,7 @@ code {
   }
 
   .usa-accordion-content {
-    padding: 0;
+    // padding: 0;
   }
 }
 

--- a/pages/all.html
+++ b/pages/all.html
@@ -1,4 +1,5 @@
 ---
+published: false
 permalink: /all/
 layout: styleguide
 title: U.S. Web Design Standards

--- a/pages/whats-new/releases.md
+++ b/pages/whats-new/releases.md
@@ -22,7 +22,8 @@ Have suggestions for a new feature or bug fix? [Open an issue](https://github.co
 
 <p class="site-subheading">{{ release.published_at | date: "%B %d, %Y" }}</p>
 
-{{ release.body | markdownify }}
+{% assign id_replace = 'id="v%-' | replace: '%', release.name %}
+{{ release.body | markdownify | replace: 'id="', id_replace }}
 
-<hr />
+<hr>
 {% endfor %}


### PR DESCRIPTION
### [:eyes: Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/patch-accordion-ids/)

This fixes #278 and https://github.com/18F/web-design-standards/issues/1225. In this PR:

* Fix code accordions generally by [replacing](https://github.com/18F/web-design-standards-docs/commit/027ae0636507c473bf0676e71ecfc6177365bea5) the `usa-button-unstyled` class with `usa-accordion-button`.
* Replace all instances of `collapsible-0` and similar IDs with more descriptive ones for each component example.
* Add missing submit buttons to some form examples that lacked them.
* Re-indent code examples to column zero, strip leading and trailing newlines, and remove trailing slashes in self-closing HTML elements (`<input>` not `<input/>`, etc.).
* Exclude `/components/all/` page from output, since we're not referencing it anywhere right now.
* Upgrade [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) to get the better [redirect template](https://github.com/jekyll/jekyll-redirect-from/blob/master/lib/jekyll-redirect-from/redirect.html).

To test:

1. Visit [the form controls page](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/patch-accordion-ids/components/form-controls/).
1. Click on any "Code" accordion to open and close it.
1. **They should all work now!** If they don't, please let me know.