### PR TITLE
upgrading accordions on typography page

### DIFF
--- a/_components/typography/02-pairing-and-styles.md
+++ b/_components/typography/02-pairing-and-styles.md
@@ -8,836 +8,826 @@ order: 02
 <p>To support both more contemporary and more traditional web design aesthetics, this font system offers recommended font pairings. Each pairing includes web hierarchy guidance on font family, weight, size, and spacing which express either more modern or more classical type design.</p>
 <p>Note: Some pairings require more font weights than others. While this allows more typographic expression, the use of more than four font weights will have a negative impact on page load performance. Find the balance that works for your product.</p>
 
-<div class="usa-accordion-bordered usa-typography-example">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="font-pairing1-docs">
-        <h5>Default: Merriweather headings, Source Sans Pro body (lite)</h5>
-      </button>
-      <div id="font-pairing1-docs" class="usa-accordion-content">
-
-        <div class="usa-grid-full">
-          <div class="usa-width-two-thirds">
-            <p>A simple serif and sans serif combination designed to communicate warmth and credibility. Strong Merriweather heading weights offer clear information hierarchy and when paired with Source Sans Pro’s easy-to-read body text, create a clean and professional feel.</p>
-            <p>This pairing is included in our design standards.</p>
-            <p>Recommended applications: digital services that feature forms; basic and text heavy sites.</p>
-            <p>Font weights included in this package:</p>
-            <ul>
-              <li>1. Merriweather, Bold 700</li>
-              <li>2. Source Sans Pro, Regular 400</li>
-              <li>3. Source Sans Pro, Bold 700</li>
-              <li>4. Source Sans Pro, Italic 400</li>
-            </ul>
-          </div>
-          <aside class="usa-width-one-third usa-end-row">
-            <h6 class="usa-heading-alt">Page Performance</h6>
-            <p><span class="usa-label-big">Fast</span></p>
-            <p>Ideal number of fonts. Will allow for optimal page load performance.</p>
-            <h6 class="usa-heading-alt">Example</h6>
-            <p>
-              <a class="media_link" href="{{ site.baseurl }}/assets/img/epa-emanifest-screenshot.png">
-                <img src="{{ site.baseurl }}/assets/img/default_example_emanifest.png" alt="EPA eManifest example">
-              </a>
-              <a href="{{ site.baseurl }}/assets/img/epa-emanifest-screenshot.png">EPA eManifest (screenshot of non-public site)</a>
-            </p>
-          </aside>
+<ul class="usa-accordion-bordered usa-typography-example">
+  <li>
+    <button class="usa-accordion-button"
+        aria-controls="font-pairing1-docs"
+        aria-expanded="false">
+      <h5>Default: Merriweather headings, Source Sans Pro body (lite)</h5>
+    </button>
+    <div id="font-pairing1-docs" class="usa-accordion-content">
+      <div class="usa-grid-full">
+        <div class="usa-width-two-thirds">
+          <p>A simple serif and sans serif combination designed to communicate warmth and credibility. Strong Merriweather heading weights offer clear information hierarchy and when paired with Source Sans Pro’s easy-to-read body text, create a clean and professional feel.</p>
+          <p>This pairing is included in our design standards.</p>
+          <p>Recommended applications: digital services that feature forms; basic and text heavy sites.</p>
+          <p>Font weights included in this package:</p>
+          <ul>
+            <li>1. Merriweather, Bold 700</li>
+            <li>2. Source Sans Pro, Regular 400</li>
+            <li>3. Source Sans Pro, Bold 700</li>
+            <li>4. Source Sans Pro, Italic 400</li>
+          </ul>
         </div>
-        <h6 class="usa-heading-alt">Web Hierarchy</h6>
-        <div class="usa-grid usa-typography-example-font">
-          <div class="usa-width-one-half">
-            <h3 class="usa-display">Display</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 52px<br>
-              line-height: 1.3em/68px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h1>Heading 1</h1>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 40px<br>
-              line-height: 1.3em/52px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h2>Heading 2</h2>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 30px<br>
-              line-height: 1.3em/39px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3>Heading 3</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 20px<br>
-              line-height: 1.3em/26px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h4>Heading 4</h4>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 17px<br>
-              line-height: 1.3em/22px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h5>Heading 5</h5>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 15px<br>
-              line-height: 1.3em/20px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h6>Heading 6</h6>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 13px<br>
-              line-height: 1.3em/17px<br>
-              text-transform: uppercase
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead">Lead <br>paragraph</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 400<br>
-              font-size: 20px<br>
-              line-height: 1.7em/34px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.5em/26px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-style: Italic<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.5em/26px
-            </p>
-          </div>
+        <aside class="usa-width-one-third usa-end-row">
+          <h6 class="usa-heading-alt">Page Performance</h6>
+          <p><span class="usa-label-big">Fast</span></p>
+          <p>Ideal number of fonts. Will allow for optimal page load performance.</p>
+          <h6 class="usa-heading-alt">Example</h6>
+          <p>
+            <a class="media_link" href="{{ site.baseurl }}/assets/img/epa-emanifest-screenshot.png">
+              <img src="{{ site.baseurl }}/assets/img/default_example_emanifest.png" alt="EPA eManifest example">
+            </a>
+            <a href="{{ site.baseurl }}/assets/img/epa-emanifest-screenshot.png">EPA eManifest (screenshot of non-public site)</a>
+          </p>
+        </aside>
+      </div>
+      <h6 class="usa-heading-alt">Web Hierarchy</h6>
+      <div class="usa-grid usa-typography-example-font">
+        <div class="usa-width-one-half">
+          <h3 class="usa-display">Display</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 52px<br>
+            line-height: 1.3em/68px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h1>Heading 1</h1>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 40px<br>
+            line-height: 1.3em/52px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h2>Heading 2</h2>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 30px<br>
+            line-height: 1.3em/39px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3>Heading 3</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 20px<br>
+            line-height: 1.3em/26px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h4>Heading 4</h4>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 17px<br>
+            line-height: 1.3em/22px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h5>Heading 5</h5>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 15px<br>
+            line-height: 1.3em/20px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h6>Heading 6</h6>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 13px<br>
+            line-height: 1.3em/17px<br>
+            text-transform: uppercase
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead">Lead <br>paragraph</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 400<br>
+            font-size: 20px<br>
+            line-height: 1.7em/34px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.5em/26px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-style: Italic<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.5em/26px
+          </p>
         </div>
       </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>
 
-<div class="usa-accordion-bordered usa-typography-example">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="font-pairing2-docs">
-        <h5>Merriweather headings, Source Sans Pro body (robust)</h5>
-      </button>
-      <div id="font-pairing2-docs" class="usa-accordion-content">
+<ul class="usa-accordion-bordered usa-typography-example">
+  <li>
+    <button class="usa-accordion-button"
+        aria-expanded="false" aria-controls="font-pairing2-docs">
+      <h5>Merriweather headings, Source Sans Pro body (robust)</h5>
+    </button>
+    <div id="font-pairing2-docs" class="usa-accordion-content">
 
-        <div class="usa-grid-full">
-          <div class="usa-width-two-thirds">
-            <p>A variation of the previous font pairing, expanded to include an additional Merriweather weight. The slimmer Merriweather headings creates an elegance that compliments weights and allows you to intentionally move users’ attention around a page.</p>
-            <p>Recommended applications: text heavy sites and more visual promotional sites.</p>
-            <p>Font weights included in this package:</p>
-            <ul>
-              <li>1. Merriweather, Bold 700</li>
-              <li>2. Merriweather, Light 300</li>
-              <li>3. Source Sans Pro, Regular 400</li>
-              <li>4. Source Sans Pro, Bold 700</li>
-              <li>5. Source Sans Pro, Italic 400</li>
-            </ul>
-          </div>
-          <aside class="usa-width-one-third usa-end-row">
-            <h6 class="usa-heading-alt">Page Performance</h6>
-            <p><span class="usa-label-big">Medium</span></p>
-            <p>Exceeds ideal number of fonts by one. May negatively impact page load performance.</p>
-            <h6 class="usa-heading-alt">Example</h6>
-            <p>
-              <a class="media_link" href="{{ site.baseurl }}/">
-                <img src="{{ site.baseurl }}/assets/img/robust_example_standardshome.png" alt="U.S. Web Design Standards homepage example">
-              </a>
-              <a href="{{ site.baseurl }}/">U.S. Web Design Standards homepage</a>
-            </p>
-          </aside>
+      <div class="usa-grid-full">
+        <div class="usa-width-two-thirds">
+          <p>A variation of the previous font pairing, expanded to include an additional Merriweather weight. The slimmer Merriweather headings creates an elegance that compliments weights and allows you to intentionally move users’ attention around a page.</p>
+          <p>Recommended applications: text heavy sites and more visual promotional sites.</p>
+          <p>Font weights included in this package:</p>
+          <ul>
+            <li>1. Merriweather, Bold 700</li>
+            <li>2. Merriweather, Light 300</li>
+            <li>3. Source Sans Pro, Regular 400</li>
+            <li>4. Source Sans Pro, Bold 700</li>
+            <li>5. Source Sans Pro, Italic 400</li>
+          </ul>
         </div>
-        <h6 class="usa-heading-alt">Web Hierarchy</h6>
-        <div class="serif-robust usa-grid usa-typography-example-font">
-          <div class="usa-width-one-half">
-            <h3 class="usa-display">Display 1</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 52px<br>
-              line-height: 1.3em/68px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3 class="usa-display usa-display-alt">Display 2</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 300<br>
-              font-size: 40px<br>
-              line-height: 1.3em/52px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h1>Heading 1</h1>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 40px<br>
-              line-height: 1.3em/52px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h2>Heading 2</h2>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 30px<br>
-              line-height: 1.3em/39px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3>Heading 3</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 20px<br>
-              line-height: 1.3em/26px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h4>Heading 4</h4>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 17px<br>
-              line-height: 1.3em/22px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h5>Heading 5</h5>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 15px<br>
-              line-height: 1.3em/20px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h6>Heading 6</h6>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 13px<br>
-              line-height: 1.3em/17px<br>
-              text-transform: uppercase
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead">Lead <br>paragraph 1</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 300<br>
-              font-size: 20px<br>
-              line-height: 1.7em/34px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead usa-font-lead-alt">Lead <br>paragraph 2</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.7em/29px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.5em/26px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-style: Italic<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.5em/26px
-            </p>
-          </div>
+        <aside class="usa-width-one-third usa-end-row">
+          <h6 class="usa-heading-alt">Page Performance</h6>
+          <p><span class="usa-label-big">Medium</span></p>
+          <p>Exceeds ideal number of fonts by one. May negatively impact page load performance.</p>
+          <h6 class="usa-heading-alt">Example</h6>
+          <p>
+            <a class="media_link" href="{{ site.baseurl }}/">
+              <img src="{{ site.baseurl }}/assets/img/robust_example_standardshome.png" alt="U.S. Web Design Standards homepage example">
+            </a>
+            <a href="{{ site.baseurl }}/">U.S. Web Design Standards homepage</a>
+          </p>
+        </aside>
+      </div>
+      <h6 class="usa-heading-alt">Web Hierarchy</h6>
+      <div class="serif-robust usa-grid usa-typography-example-font">
+        <div class="usa-width-one-half">
+          <h3 class="usa-display">Display 1</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 52px<br>
+            line-height: 1.3em/68px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3 class="usa-display usa-display-alt">Display 2</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 300<br>
+            font-size: 40px<br>
+            line-height: 1.3em/52px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h1>Heading 1</h1>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 40px<br>
+            line-height: 1.3em/52px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h2>Heading 2</h2>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 30px<br>
+            line-height: 1.3em/39px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3>Heading 3</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 20px<br>
+            line-height: 1.3em/26px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h4>Heading 4</h4>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 17px<br>
+            line-height: 1.3em/22px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h5>Heading 5</h5>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 15px<br>
+            line-height: 1.3em/20px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h6>Heading 6</h6>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 13px<br>
+            line-height: 1.3em/17px<br>
+            text-transform: uppercase
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead">Lead <br>paragraph 1</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 300<br>
+            font-size: 20px<br>
+            line-height: 1.7em/34px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead usa-font-lead-alt">Lead <br>paragraph 2</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.7em/29px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.5em/26px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-style: Italic<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.5em/26px
+          </p>
         </div>
       </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>
 
-<div class="usa-accordion-bordered usa-typography-example">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="font-pairing3-docs">
-        <h5>Merriweather headings and body</h5>
-      </button>
-      <div id="font-pairing3-docs" class="usa-accordion-content">
+<ul class="usa-accordion-bordered usa-typography-example">
+  <li>
+    <button class="usa-accordion-button"
+        aria-expanded="false" aria-controls="font-pairing3-docs">
+      <h5>Merriweather headings and body</h5>
+    </button>
+    <div id="font-pairing3-docs" class="usa-accordion-content">
 
-        <div class="usa-grid-full">
-          <div class="usa-width-two-thirds">
-            <p>The most formal of the options, this pairing uses Merriweather for both headings and body text. The full suite of serif styles communicates trustworthiness, while Merriweather’s contemporary shapes convey freshness and a modern relevance. The weights are designed to pair together for easy reading and clean page design. Light use of Source Sans Pro suggested for legibility of small text needs.</p>
-            <p>Recommended applications: sites which need to convey reliability and trust; basic and text heavy sites.</p>
-            <p>Font weights included in this package:</p>
-            <ul>
-              <li>1. Merriweather, Bold 700</li>
-              <li>2. Merriweather, Regular 400</li>
-              <li>3. Merriweather, Italic 400</li>
-              <li>4. Merriweather, Light 300</li>
-              <li>5. Source Sans Pro, Regular 400</li>
-            </ul>
-          </div>
-          <aside class="usa-width-one-third usa-end-row">
-            <h6 class="usa-heading-alt">Page Performance</h6>
-            <p><span class="usa-label-big">Medium</span></p>
-            <p>Exceeds ideal number of fonts by one. May negatively impact page load performance.</p>
-            <h6 class="usa-heading-alt">Example</h6>
-            <p>
-              <a class="media_link" href="http://playbook.cio.gov">
-                <img src="{{ site.baseurl }}/assets/img/merriweatheronly_example_playbook.png" alt="U.S. Digital Service Playbook example">
-              </a>
-              <a href="http://playbook.cio.gov">U.S. Digital Service Playbook</a>
-            </p>
-          </aside>
+      <div class="usa-grid-full">
+        <div class="usa-width-two-thirds">
+          <p>The most formal of the options, this pairing uses Merriweather for both headings and body text. The full suite of serif styles communicates trustworthiness, while Merriweather’s contemporary shapes convey freshness and a modern relevance. The weights are designed to pair together for easy reading and clean page design. Light use of Source Sans Pro suggested for legibility of small text needs.</p>
+          <p>Recommended applications: sites which need to convey reliability and trust; basic and text heavy sites.</p>
+          <p>Font weights included in this package:</p>
+          <ul>
+            <li>1. Merriweather, Bold 700</li>
+            <li>2. Merriweather, Regular 400</li>
+            <li>3. Merriweather, Italic 400</li>
+            <li>4. Merriweather, Light 300</li>
+            <li>5. Source Sans Pro, Regular 400</li>
+          </ul>
         </div>
-        <h6 class="usa-heading-alt">Web Hierarchy</h6>
-        <div class="serif-robust serif-sans-minor serif-body usa-grid usa-typography-example-font">
-          <div class="usa-width-one-half">
-            <h3 class="usa-display">Display 1</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 52px<br>
-              line-height: 1.3em/68px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3 class="usa-display usa-display-alt">Display 2</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 300<br>
-              font-size: 40px<br>
-              line-height: 1.3em/52px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h1>Heading 1</h1>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 40px<br>
-              line-height: 1.3em/52px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h2>Heading 2</h2>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 30px<br>
-              line-height: 1.3em/39px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3>Heading 3</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 20px<br>
-              line-height: 1.3em/26px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h4>Heading 4</h4>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 17px<br>
-              line-height: 1.3em/22px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h5>Heading 5</h5>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 700<br>
-              font-size: 15px<br>
-              line-height: 1.3em/20px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h6>Heading 6</h6>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 13px<br>
-              line-height: 1.3em/17px<br>
-              text-transform: uppercase
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead">Lead <br>paragraph 1</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 300<br>
-              font-size: 20px<br>
-              line-height: 1.7em/34px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead usa-font-lead-alt">Lead <br>paragraph 2</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.7em/29px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 400<br>
-              font-size: 15px<br>
-              line-height: 1.7em/26px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-style: Italic<br>
-              font-weight: 400<br>
-              font-size: 15px<br>
-              line-height: 1.7em/26px
-            </p>
-          </div>
+        <aside class="usa-width-one-third usa-end-row">
+          <h6 class="usa-heading-alt">Page Performance</h6>
+          <p><span class="usa-label-big">Medium</span></p>
+          <p>Exceeds ideal number of fonts by one. May negatively impact page load performance.</p>
+          <h6 class="usa-heading-alt">Example</h6>
+          <p>
+            <a class="media_link" href="http://playbook.cio.gov">
+              <img src="{{ site.baseurl }}/assets/img/merriweatheronly_example_playbook.png" alt="U.S. Digital Service Playbook example">
+            </a>
+            <a href="http://playbook.cio.gov">U.S. Digital Service Playbook</a>
+          </p>
+        </aside>
+      </div>
+      <h6 class="usa-heading-alt">Web Hierarchy</h6>
+      <div class="serif-robust serif-sans-minor serif-body usa-grid usa-typography-example-font">
+        <div class="usa-width-one-half">
+          <h3 class="usa-display">Display 1</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 52px<br>
+            line-height: 1.3em/68px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3 class="usa-display usa-display-alt">Display 2</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 300<br>
+            font-size: 40px<br>
+            line-height: 1.3em/52px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h1>Heading 1</h1>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 40px<br>
+            line-height: 1.3em/52px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h2>Heading 2</h2>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 30px<br>
+            line-height: 1.3em/39px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3>Heading 3</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 20px<br>
+            line-height: 1.3em/26px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h4>Heading 4</h4>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 17px<br>
+            line-height: 1.3em/22px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h5>Heading 5</h5>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 700<br>
+            font-size: 15px<br>
+            line-height: 1.3em/20px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h6>Heading 6</h6>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 13px<br>
+            line-height: 1.3em/17px<br>
+            text-transform: uppercase
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead">Lead <br>paragraph 1</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 300<br>
+            font-size: 20px<br>
+            line-height: 1.7em/34px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead usa-font-lead-alt">Lead <br>paragraph 2</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.7em/29px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 400<br>
+            font-size: 15px<br>
+            line-height: 1.7em/26px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-style: Italic<br>
+            font-weight: 400<br>
+            font-size: 15px<br>
+            line-height: 1.7em/26px
+          </p>
         </div>
       </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>
 
-<div class="usa-accordion-bordered usa-typography-example">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="font-pairing4-docs">
-        <h5>Source Sans Pro headings, Merriweather body</h5>
-      </button>
-      <div id="font-pairing4-docs" class="usa-accordion-content">
+<ul class="usa-accordion-bordered usa-typography-example">
+  <li>
+    <button class="usa-accordion-button"
+        aria-expanded="false" aria-controls="font-pairing4-docs">
+      <h5>Source Sans Pro headings, Merriweather body</h5>
+    </button>
+    <div id="font-pairing4-docs" class="usa-accordion-content">
 
-        <div class="usa-grid-full">
-          <div class="usa-width-two-thirds">
-            <p>A variation on the serif and sans serif pairing, this combination uses multiple weights of Source Sans Pro for clear headings combined with the formal feeling of Merriweather for body text. This pair similarly communicates professionalism, with extra emphasis on sleek and legible headings.</p>
-            <p>Recommended applications: digital services that feature forms; basic and text heavy sites; marketing sites.</p>
-            <p>Font weights included in this package:</p>
-            <ul>
-              <li>1. Source Sans Pro, Light 300</li>
-              <li>2. Source Sans Pro, Regular 400</li>
-              <li>3. Source Sans Pro, Bold 700</li>
-              <li>4. Merriweather, Regular 400</li>
-              <li>5. Merriweather, Italic 400</li>
-              <li>6. Merriweather, Bold 700</li>
-            </ul>
-          </div>
-          <aside class="usa-width-one-third usa-end-row">
-            <h6 class="usa-heading-alt">Page Performance</h6>
-            <p><span class="usa-label-big">Medium</span></p>
-            <p>Exceeds ideal number of fonts by two. May negatively impact page load performance.</p>
-          </aside>
+      <div class="usa-grid-full">
+        <div class="usa-width-two-thirds">
+          <p>A variation on the serif and sans serif pairing, this combination uses multiple weights of Source Sans Pro for clear headings combined with the formal feeling of Merriweather for body text. This pair similarly communicates professionalism, with extra emphasis on sleek and legible headings.</p>
+          <p>Recommended applications: digital services that feature forms; basic and text heavy sites; marketing sites.</p>
+          <p>Font weights included in this package:</p>
+          <ul>
+            <li>1. Source Sans Pro, Light 300</li>
+            <li>2. Source Sans Pro, Regular 400</li>
+            <li>3. Source Sans Pro, Bold 700</li>
+            <li>4. Merriweather, Regular 400</li>
+            <li>5. Merriweather, Italic 400</li>
+            <li>6. Merriweather, Bold 700</li>
+          </ul>
         </div>
-        <h6 class="usa-heading-alt">Web Hierarchy</h6>
-        <div class="sans-style serif-body usa-grid usa-typography-example-font">
-          <div class="usa-width-one-half">
-            <h3 class="usa-display">Display 1</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 59px<br>
-              line-height: 1.3em/77px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3 class="usa-display usa-display-alt">Display 2</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 300<br>
-              font-size: 44px<br>
-              line-height: 1.3em/57px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h1>Heading 1</h1>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 44px<br>
-              line-height: 1.3em/57px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h2>Heading 2</h2>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 34px<br>
-              line-height: 1.3em/44px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3>Heading 3</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 24px<br>
-              line-height: 1.3em/31px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h4>Heading 4</h4>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 19px<br>
-              line-height: 1.3em/25px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h5>Heading 5</h5>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 16px<br>
-              line-height: 1.3em/21px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h6>Heading 6</h6>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 13px<br>
-              line-height: 1.3em/17px<br>
-              text-transform: uppercase
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead">Lead <br>paragraph</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 300<br>
-              font-size: 22px<br>
-              line-height: 1.5em/33px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-weight: 400<br>
-              font-size: 15px<br>
-              line-height: 1.7em/26px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Merriweather’<br>
-              font-style: Italic<br>
-              font-weight: 400<br>
-              font-size: 15px<br>
-              line-height: 1.7em/26px
-            </p>
-          </div>
+        <aside class="usa-width-one-third usa-end-row">
+          <h6 class="usa-heading-alt">Page Performance</h6>
+          <p><span class="usa-label-big">Medium</span></p>
+          <p>Exceeds ideal number of fonts by two. May negatively impact page load performance.</p>
+        </aside>
+      </div>
+      <h6 class="usa-heading-alt">Web Hierarchy</h6>
+      <div class="sans-style serif-body usa-grid usa-typography-example-font">
+        <div class="usa-width-one-half">
+          <h3 class="usa-display">Display 1</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 59px<br>
+            line-height: 1.3em/77px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3 class="usa-display usa-display-alt">Display 2</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 300<br>
+            font-size: 44px<br>
+            line-height: 1.3em/57px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h1>Heading 1</h1>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 44px<br>
+            line-height: 1.3em/57px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h2>Heading 2</h2>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 34px<br>
+            line-height: 1.3em/44px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3>Heading 3</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 24px<br>
+            line-height: 1.3em/31px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h4>Heading 4</h4>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 19px<br>
+            line-height: 1.3em/25px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h5>Heading 5</h5>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 16px<br>
+            line-height: 1.3em/21px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h6>Heading 6</h6>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 13px<br>
+            line-height: 1.3em/17px<br>
+            text-transform: uppercase
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead">Lead <br>paragraph</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 300<br>
+            font-size: 22px<br>
+            line-height: 1.5em/33px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-weight: 400<br>
+            font-size: 15px<br>
+            line-height: 1.7em/26px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Merriweather’<br>
+            font-style: Italic<br>
+            font-weight: 400<br>
+            font-size: 15px<br>
+            line-height: 1.7em/26px
+          </p>
         </div>
       </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>
 
-<div class="usa-accordion-bordered usa-typography-example usa-accordion-docs">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled"
-          aria-expanded="false" aria-controls="font-pairing5-docs">
-        <h5>Source Sans Pro headings and body</h5>
-      </button>
-      <div id="font-pairing5-docs" class="usa-accordion-content">
+<ul class="usa-accordion-bordered usa-typography-example">
+  <li>
+    <button class="usa-accordion-button"
+        aria-expanded="false" aria-controls="font-pairing5-docs">
+      <h5>Source Sans Pro headings and body</h5>
+    </button>
+    <div id="font-pairing5-docs" class="usa-accordion-content">
 
-        <div class="usa-grid-full">
-          <div class="usa-width-two-thirds">
-            <p>Inspired by the growth of simple and welcoming type in modern web UI design, this suite uses Source Sans Pro exclusively. With a range of weights designed to fit into heading styles to clearly communicate hierarchy of information, this pairing can support both extremely simple designs and more polished, promotional sites.</p>
-            <p>Recommended applications: digital services that feature forms; basic and text heavy sites; marketing sites.</p>
-            <p>Font weights included in this package:</p>
-            <ul>
-              <li>1. Source Sans Pro, Light 300</li>
-              <li>2. Source Sans Pro, Regular 400</li>
-              <li>3. Source Sans Pro, Bold 700</li>
-              <li>4. Source Sans Pro, Italic 400</li>
-            </ul>
-          </div>
-          <aside class="usa-width-one-third usa-end-row">
-            <h6 class="usa-heading-alt">Page Performance</h6>
-            <p><span class="usa-label-big">Fast</span></p>
-            <p>Ideal number of fonts. Will allow for optimal page load performance.</p>
-            <h6 class="usa-heading-alt">Example</h6>
-            <p>
-              <a class="media_link" href="{{ site.baseurl }}/assets/img/va-appeals-screenshot.png">
-                <img src="{{ site.baseurl }}/assets/img/ssponly_example_va.png" alt="Veterans Affairs appeals review example">
-              </a>
-              <a href="{{ site.baseurl }}/assets/img/va-appeals-screenshot.png">Department of Veterans Affairs appeals review (screenshot of non-public site)</a>
-            </p>
-          </aside>
+      <div class="usa-grid-full">
+        <div class="usa-width-two-thirds">
+          <p>Inspired by the growth of simple and welcoming type in modern web UI design, this suite uses Source Sans Pro exclusively. With a range of weights designed to fit into heading styles to clearly communicate hierarchy of information, this pairing can support both extremely simple designs and more polished, promotional sites.</p>
+          <p>Recommended applications: digital services that feature forms; basic and text heavy sites; marketing sites.</p>
+          <p>Font weights included in this package:</p>
+          <ul>
+            <li>1. Source Sans Pro, Light 300</li>
+            <li>2. Source Sans Pro, Regular 400</li>
+            <li>3. Source Sans Pro, Bold 700</li>
+            <li>4. Source Sans Pro, Italic 400</li>
+          </ul>
         </div>
-        <h6 class="usa-heading-alt">Web Hierarchy</h6>
-        <div class="sans-style usa-grid usa-typography-example-font">
-          <div class="usa-width-one-half">
-            <h3 class="usa-display">Display 1</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 59px<br>
-              line-height: 1.3em/77px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3 class="usa-display usa-display-alt">Display 2</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 300<br>
-              font-size: 44px<br>
-              line-height: 1.3em/57px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h1>Heading 1</h1>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 44px<br>
-              line-height: 1.3em/57px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h2>Heading 2</h2>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 34px<br>
-              line-height: 1.3em/44px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h3>Heading 3</h3>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 24px<br>
-              line-height: 1.3em/31px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h4>Heading 4</h4>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 19px<br>
-              line-height: 1.3em/25px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h5>Heading 5</h5>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 700<br>
-              font-size: 16px<br>
-              line-height: 1.3em/21px
-            </p>
-          </div>
-          <div class="usa-width-one-half">
-            <h6>Heading 6</h6>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 13px<br>
-              line-height: 1.3em/17px<br>
-              text-transform: uppercase
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="usa-font-lead">Lead <br>paragraph</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 300<br>
-              font-size: 22px<br>
-              line-height: 1.5em/33px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.5em/26px
-            </p>
-          </div>
-          <div class="usa-font-example usa-width-one-half">
-            <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
-          </div>
-          <div class="usa-width-one-half usa-end-row">
-            <p class="usa-monospace">
-              font-family: ‘Source Sans Pro’<br>
-              font-style: Italic<br>
-              font-weight: 400<br>
-              font-size: 17px<br>
-              line-height: 1.5em/26px
-            </p>
-          </div>
+        <aside class="usa-width-one-third usa-end-row">
+          <h6 class="usa-heading-alt">Page Performance</h6>
+          <p><span class="usa-label-big">Fast</span></p>
+          <p>Ideal number of fonts. Will allow for optimal page load performance.</p>
+          <h6 class="usa-heading-alt">Example</h6>
+          <p>
+            <a class="media_link" href="{{ site.baseurl }}/assets/img/va-appeals-screenshot.png">
+              <img src="{{ site.baseurl }}/assets/img/ssponly_example_va.png" alt="Veterans Affairs appeals review example">
+            </a>
+            <a href="{{ site.baseurl }}/assets/img/va-appeals-screenshot.png">Department of Veterans Affairs appeals review (screenshot of non-public site)</a>
+          </p>
+        </aside>
+      </div>
+      <h6 class="usa-heading-alt">Web Hierarchy</h6>
+      <div class="sans-style usa-grid usa-typography-example-font">
+        <div class="usa-width-one-half">
+          <h3 class="usa-display">Display 1</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 59px<br>
+            line-height: 1.3em/77px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3 class="usa-display usa-display-alt">Display 2</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 300<br>
+            font-size: 44px<br>
+            line-height: 1.3em/57px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h1>Heading 1</h1>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 44px<br>
+            line-height: 1.3em/57px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h2>Heading 2</h2>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 34px<br>
+            line-height: 1.3em/44px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h3>Heading 3</h3>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 24px<br>
+            line-height: 1.3em/31px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h4>Heading 4</h4>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 19px<br>
+            line-height: 1.3em/25px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h5>Heading 5</h5>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 700<br>
+            font-size: 16px<br>
+            line-height: 1.3em/21px
+          </p>
+        </div>
+        <div class="usa-width-one-half">
+          <h6>Heading 6</h6>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 13px<br>
+            line-height: 1.3em/17px<br>
+            text-transform: uppercase
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="usa-font-lead">Lead <br>paragraph</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 300<br>
+            font-size: 22px<br>
+            line-height: 1.5em/33px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph">Body copy. A series of sentences together which make a paragraph.</p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.5em/26px
+          </p>
+        </div>
+        <div class="usa-font-example usa-width-one-half">
+          <p class="font-example-paragraph"><em>Italic body copy. A series of sentences together which make a paragraph.</em></p>
+        </div>
+        <div class="usa-width-one-half usa-end-row">
+          <p class="usa-monospace">
+            font-family: ‘Source Sans Pro’<br>
+            font-style: Italic<br>
+            font-weight: 400<br>
+            font-size: 17px<br>
+            line-height: 1.5em/26px
+          </p>
         </div>
       </div>
-    </li>
-  </ul>
-</div>
+    </div>
+  </li>
+</ul>


### PR DESCRIPTION
👀  on [Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/typography-accordions/)

the typography examples were using the old accordion styles and weren't expanding properly as a result