### PR TITLE
moving from 1.0.0 to 1.1.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title:  U.S. Web Design Standards
-version: 1.0.0
+version: 1.1.0
 google_analytics_ua: UA-48605964-43
 
 # this is for pages that don't have a permalink (primarily posts)


### PR DESCRIPTION
### 👀  [Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/bump-version/getting-started/download/)

moving the site version to 1.1.0. This updates the download link to point to the new version of the standards, among other things.

