### PR TITLE
Updating retired design asset text

### DIFF
--- a/_includes/download-buttons-design-retired.html
+++ b/_includes/download-buttons-design-retired.html
@@ -2,5 +2,4 @@
 These `uswds-assets-*.zip` files are generated in 18F/web-design-standards-assets
 repository. See: https://github.com/18F/web-design-standards-assets
 {% endcomment %}
-
 <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>

--- a/_includes/download-buttons-design-retired.html
+++ b/_includes/download-buttons-design-retired.html
@@ -1,0 +1,6 @@
+{% comment %}
+These `uswds-assets-*.zip` files are generated in 18F/web-design-standards-assets
+repository. See: https://github.com/18F/web-design-standards-assets
+{% endcomment %}
+
+<a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>

--- a/_includes/download-buttons-design.html
+++ b/_includes/download-buttons-design.html
@@ -7,7 +7,3 @@ repository. See: https://github.com/18F/web-design-standards-assets
   <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-sketch.zip" onclick="ga('send', 'event', 'Downloaded design files - Sketch', 'Clicked download design files button inside site');">Download design files (Sketch)</a>
   <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-eps.zip" onclick="ga('send', 'event', 'Downloaded design files - EPS', 'Clicked download design files button inside site');">Download design files (EPS)</a>
 </div>
-
-<h3>Retired design files </h3>
-<p>The following design files are no longer being maintained by the U.S. Web Design Standards team as of version 1.0.0 — the most recent versions remain available for download at the links below. While the Standards team is no longer maintaining these files, we'd love to hear from any teams that are using these files and adding new components when new versions of the Standards are released. [Send us an email](mailto:@uswebdesignstandards@gsa.gov).</p>
-<a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>

--- a/_includes/download-buttons-design.html
+++ b/_includes/download-buttons-design.html
@@ -9,5 +9,5 @@ repository. See: https://github.com/18F/web-design-standards-assets
 </div>
 
 <h3>Retired design files </h3>
-<p>The following design files have been retired and are available to maintained by the U.S. Web Design Standards.</p>
+<p>The following design files are no longer being maintained by the U.S. Web Design Standards team as of version 1.0.0 — the most recent versions remain available for download at the links below. While the Standards team is no longer maintaining these files, we'd love to hear from any teams that are using these files and adding new components when new versions of the Standards are released. [Send us an email](mailto:@uswebdesignstandards@gsa.gov).</p>
 <a class="link-download" href="{{ site.baseurl }}/files/uswds-assets-omnigraffle.zip" onclick="ga('send', 'event', 'Downloaded design files - OmniGraffle', 'Clicked download design files button inside site');">Download design files (OmniGraffle)</a>

--- a/pages/getting-started/designers.md
+++ b/pages/getting-started/designers.md
@@ -18,6 +18,11 @@ All of these designs are also available in various file formats, which are avail
 
 {% include download-buttons-design.html %}
 
+### Retired design files
+The following design files are no longer being maintained by the U.S. Web Design Standards team as of version 1.0.0 — the most recent versions remain available for download at the links below. While the Standards team is no longer maintaining these files, we'd love to hear from any teams that are using these files and adding new components when new versions of the Standards are released. [Send us an email](mailto:@uswebdesignstandards@gsa.gov).
+
+{% include download-buttons-design-retired.html %}
+
 ## Notes on accessibility
 
 All of our designs meet the [WCAG 2.0 AA accessibility guidelines](https://www.w3.org/TR/WCAG20/) and are compliant with [Section 508 of the Rehabilitation Act](http://www.section508.gov/). If you choose to customize these designs, please make sure they continue to meet the requirements listed in the “Accessibility” section of each design.

--- a/pages/getting-started/designers.md
+++ b/pages/getting-started/designers.md
@@ -19,7 +19,7 @@ All of these designs are also available in various file formats, which are avail
 {% include download-buttons-design.html %}
 
 ### Retired design files
-The following design files are no longer being maintained by the U.S. Web Design Standards team as of version 1.0.0 — the most recent versions remain available for download at the links below. While the Standards team is no longer maintaining these files, we'd love to hear from any teams that are using these files and adding new components when new versions of the Standards are released. [Send us an email](mailto:@uswebdesignstandards@gsa.gov).
+The following design files are no longer being maintained by the U.S. Web Design Standards team as of version 1.0.0. The most recent versions remain available for download at the links below. While the Standards team is no longer maintaining these files, we'd love to hear from any teams that are using these files and adding new components when new versions of the Standards are released. [Send us an email](mailto:@uswebdesignstandards@gsa.gov).
 
 {% include download-buttons-design-retired.html %}
 


### PR DESCRIPTION
fixes #288 

The text describing our retired design assets was confusing. 

[Preview on Federalist](https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/retired-text/)