### PR TITLE
adding paragraph width class to example alerts

### DIFF
--- a/_includes/code/accordion.html
+++ b/_includes/code/accordion.html
@@ -1,11 +1,7 @@
 <div class="usa-accordion-bordered usa-code-sample">
-  <ul class="usa-unstyled-list">
-    <li>
-      {% assign _id = include.component | prepend: 'code-' %}
-      <button class="usa-accordion-button" aria-controls="{{ _id }}">Code</button>
-      <div id="{{ _id }}" class="usa-accordion-content">
-        {% include code/syntax.html component=include.component %}
-      </div>
-    </li>
-  </ul>
+  {% assign _id = include.component | prepend: 'code-' %}
+  <button class="usa-accordion-button" aria-controls="{{ _id }}">Code</button>
+  <div id="{{ _id }}" class="usa-accordion-content">
+    {% include code/syntax.html component=include.component %}
+  </div>
 </div>

--- a/_includes/perf_example.html
+++ b/_includes/perf_example.html
@@ -1,8 +1,8 @@
-<div class="usa-alert usa-alert-info">
+<div class="usa-alert usa-alert-info usa-alert-paragraph">
   <div class="usa-alert-body">
-    <h3 class="usa-alert-heading">example</h3>
+    <h3 class="usa-alert-heading">Example</h3>
     <div class="usa-alert-text">
-      {{ include.text | markdownify }}
+      <p>{{ include.text | markdownify }}</p>
     </div>
   </div>
 </div>

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -1402,7 +1402,7 @@ hr {
   background: $color-gray-lighter;
   border: none;
   height: 1px;
-  margin: 3em 0; 
+  margin: 3em 0;
 }
 
 iframe {


### PR DESCRIPTION
This adds a class to the alerts used in the performance guide to ensure that they aren't wider than the paragraph content.

The class is on track to be added to the next version of the standards via 18F/web-design-standards#1925