### PR TITLE
Link to better Drupal implementation

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -7,12 +7,12 @@
   notes: "This package provides access to the Standards in [Django](https://www.djangoproject.com/) applications."
 
 - name: Drupal
-  url: https://github.com/18F/web-design-standards-drupal
+  url: https://www.drupal.org/project/uswds
   author:
-    name: 18F
-    url: https://github.com/18F
-  version: 0.8.1
-  notes: "This is a work in progress. See the [project board](https://waffle.io/18F/web-design-standards-drupal) for more info."
+    name: Brock Fanning
+    url: https://www.drupal.org/u/brockfanning
+  version: 1.x
+  notes: "This base theme focuses on tweaking Drupal's markup so that it will work with the USWDS library. Some CSS is added to deal with unavoidable Drupal quirks, but only as a last resort."
 
 - name: npm and node-sass
   url: https://github.com/openbrian/18f-contrib-web-design-standards


### PR DESCRIPTION
This updates the implementation info to link to @brockfanning's [Drupal project](https://www.drupal.org/project/uswds) instead of our unmaintained one. Brock, let us know if you'd like any of this info listed differently.

cc @fureigh ❤️ 