### PR TITLE
removing blockquote on http2 perf

### DIFF
--- a/_includes/perf_example.html
+++ b/_includes/perf_example.html
@@ -2,7 +2,7 @@
   <div class="usa-alert-body">
     <h3 class="usa-alert-heading">Example</h3>
     <div class="usa-alert-text">
-      <p>{{ include.text | markdownify }}</p>
+      {{ include.text | markdownify }}
     </div>
   </div>
 </div>

--- a/pages/performance/http2.md
+++ b/pages/performance/http2.md
@@ -5,12 +5,12 @@ category: Getting started
 layout: styleguide
 ---
 
-> ## TL;DR:
-> 
-> If possible, enable HTTP/2 support on your server for dramatic performance gains. When using HTTP/2:
-> 
-> * Do not use the [domain splitting](#domain-splitting) technique.
-> * Prefer small, modular files rather than [concatenating](#concatenation) them to reduce connection overhead.
+## TL;DR:
+
+If possible, enable HTTP/2 support on your server for dramatic performance gains. When using HTTP/2:
+
+* Do not use the [domain splitting](#domain-splitting) technique.
+* Prefer small, modular files rather than [concatenating](#concatenation) them to reduce connection overhead.
 
 ## What is HTTP/2?
 


### PR DESCRIPTION
removing the blockquote on one of the performance pages because we don't have styles for this in the standards so it just indents the paragraph