### PR TITLE
Add explicit SASS variable names to color page

### DIFF
--- a/_components/colors/01-palette.md
+++ b/_components/colors/01-palette.md
@@ -17,25 +17,25 @@ order: 01
   <div class="usa-color-square usa-color-primary">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#0071bc</p>
-      <p class="usa-color-name">primary</p>
+      <p class="usa-color-name">$color-primary</p>
     </div>
   </div>
   <div class="usa-color-square usa-color-primary-darker usa-mobile-end-row">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#205493</p>
-      <p class="usa-color-name">primary-darker</p>
+      <p class="usa-color-name">$color-primary-darker</p>
     </div>
   </div>
   <div class="usa-color-square usa-color-primary-darkest">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#112e51</p>
-      <p class="usa-color-name">primary-darkest</p>
+      <p class="usa-color-name">$color-primary-darkest</p>
     </div>
   </div>
   <div class="usa-color-square usa-color-base usa-end-row">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#212121</p>
-      <p class="usa-color-name">base</p>
+      <p class="usa-color-name">$color-base</p>
     </div>
   </div>
 </div>
@@ -44,19 +44,19 @@ order: 01
   <div class="usa-color-square usa-color-gray-dark">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#323a45</p>
-      <p class="usa-color-name">gray-dark</p>
+      <p class="usa-color-name">$color-gray-dark</p>
     </div>
   </div>
   <div class="usa-color-square usa-color-gray-light usa-mobile-end-row">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#aeb0b5</p>
-      <p class="usa-color-name">gray-light</p>
+      <p class="usa-color-name">$color-gray-light</p>
     </div>
   </div>
   <div class="usa-color-square usa-color-white">
     <div class="usa-color-inner-content">
       <p class="usa-color-hex">#ffffff</p>
-      <p class="usa-color-name">white</p>
+      <p class="usa-color-name">$color-white</p>
     </div>
   </div>
 </div>
@@ -70,31 +70,31 @@ order: 01
     <div class="usa-color-short usa-color-primary-alt">
     </div>
       <p class="usa-color-hex">#02bfe7</p>
-      <p class="usa-color-name">primary-alt</p>
+      <p class="usa-color-name">$color-primary-alt</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-primary-alt-darkest">
     </div>
       <p class="usa-color-hex">#046b99</p>
-      <p class="usa-color-name">primary-alt-darkest</p>
+      <p class="usa-color-name">$color-primary-alt-darkest</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-primary-alt-dark">
     </div>
       <p class="usa-color-hex">#00a6d2</p>
-      <p class="usa-color-name">primary-alt-dark</p>
+      <p class="usa-color-name">$color-primary-alt-dark</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-primary-alt-light">
     </div>
       <p class="usa-color-hex">#9bdaf1</p>
-      <p class="usa-color-name">primary-alt-light</p>
+      <p class="usa-color-name">$color-primary-alt-light</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-primary-alt-lightest">
     </div>
       <p class="usa-color-hex">#e1f3f8</p>
-      <p class="usa-color-name">primary-alt-lightest</p>
+      <p class="usa-color-name">$color-primary-alt-lightest</p>
   </div>
 </div>
 
@@ -103,31 +103,31 @@ order: 01
     <div class="usa-color-short usa-color-secondary">
     </div>
       <p class="usa-color-hex">#e31c3d</p>
-      <p class="usa-color-name">secondary</p>
+      <p class="usa-color-name">$color-secondary</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-secondary-darkest">
     </div>
       <p class="usa-color-hex">#981b1e</p>
-      <p class="usa-color-name">secondary-darkest</p>
+      <p class="usa-color-name">$color-secondary-darkest</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-secondary-dark">
     </div>
       <p class="usa-color-hex">#cd2026</p>
-      <p class="usa-color-name">secondary-dark</p>
+      <p class="usa-color-name">$color-secondary-dark</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-secondary-light">
     </div>
       <p class="usa-color-hex">#e59393</p>
-      <p class="usa-color-name">secondary-light</p>
+      <p class="usa-color-name">$color-secondary-light</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-secondary-lightest">
     </div>
       <p class="usa-color-hex">#f9dede</p>
-      <p class="usa-color-name">secondary-lightest</p>
+      <p class="usa-color-name">$color-secondary-lightest</p>
   </div>
 </div>
 
@@ -140,31 +140,31 @@ order: 01
     <div class="usa-color-short usa-color-gray-dark">
     </div>
       <p class="usa-color-hex">#323a45</p>
-      <p class="usa-color-name">gray-dark</p>
+      <p class="usa-color-name">$color-gray-dark</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gray">
     </div>
       <p class="usa-color-hex">#5b616b</p>
-      <p class="usa-color-name">gray</p>
+      <p class="usa-color-name">$color-gray</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gray-light">
     </div>
       <p class="usa-color-hex">#aeb0b5</p>
-      <p class="usa-color-name">gray-light</p>
+      <p class="usa-color-name">$color-gray-light</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gray-lighter">
     </div>
       <p class="usa-color-hex">#d6d7d9</p>
-      <p class="usa-color-name">gray-lighter</p>
+      <p class="usa-color-name">$color-gray-lighter</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gray-lightest">
     </div>
       <p class="usa-color-hex">#f1f1f1</p>
-      <p class="usa-color-name">gray-lightest</p>
+      <p class="usa-color-name">$color-gray-lightest</p>
   </div>
 </div>
 
@@ -173,13 +173,13 @@ order: 01
     <div class="usa-color-short usa-color-gray-warm-dark">
     </div>
       <p class="usa-color-hex">#494440</p>
-      <p class="usa-color-name">gray-warm-dark</p>
+      <p class="usa-color-name">$color-gray-warm-dark</p>
   </div>
   <div class="color-small usa-end-row">
     <div class="usa-color-short usa-color-gray-warm-light">
     </div>
       <p class="usa-color-hex">#e4e2e0</p>
-      <p class="usa-color-name">gray-warm-light</p>
+      <p class="usa-color-name">$color-gray-warm-light</p>
   </div>
 </div>
 
@@ -188,13 +188,13 @@ order: 01
     <div class="usa-color-short usa-color-primary-darkest">
     </div>
       <p class="usa-color-hex">#112e51</p>
-      <p class="usa-color-name">primary-darkest</p>
+      <p class="usa-color-name">$color-primary-darkest</p>
   </div>
   <div class="color-small usa-end-row">
     <div class="usa-color-short usa-color-gray-cool-light">
     </div>
       <p class="usa-color-hex">#dce4ef</p>
-      <p class="usa-color-name">gray-cool-light</p>
+      <p class="usa-color-name">$color-gray-cool-light</p>
   </div>
 </div>
 
@@ -207,25 +207,25 @@ order: 01
     <div class="usa-color-short usa-color-gold">
     </div>
       <p class="usa-color-hex">#fdb81e</p>
-      <p class="usa-color-name">gold</p>
+      <p class="usa-color-name">$color-gold</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gold-light">
     </div>
       <p class="usa-color-hex">#f9c642</p>
-      <p class="usa-color-name">gold-light</p>
+      <p class="usa-color-name">$color-gold-light</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gold-lighter">
     </div>
       <p class="usa-color-hex">#fad980</p>
-      <p class="usa-color-name">gold-lighter</p>
+      <p class="usa-color-name">$color-gold-lighter</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-gold-lightest usa-end-row">
     </div>
       <p class="usa-color-hex">#fff1d2</p>
-      <p class="usa-color-name">gold-lightest</p>
+      <p class="usa-color-name">$color-gold-lightest</p>
   </div>
 </div>
 
@@ -234,25 +234,25 @@ order: 01
     <div class="usa-color-short usa-color-green">
     </div>
       <p class="usa-color-hex">#2e8540</p>
-      <p class="usa-color-name">green</p>
+      <p class="usa-color-name">$color-green</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-green-light">
     </div>
       <p class="usa-color-hex">#4aa564</p>
-      <p class="usa-color-name">green-light</p>
+      <p class="usa-color-name">$color-green-light</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-green-lighter">
     </div>
       <p class="usa-color-hex">#94bfa2</p>
-      <p class="usa-color-name">green-lighter</p>
+      <p class="usa-color-name">$color-green-lighter</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-green-lightest usa-end-row">
     </div>
       <p class="usa-color-hex">#e7f4e4</p>
-      <p class="usa-color-name">green-lightest</p>
+      <p class="usa-color-name">$color-green-lightest</p>
   </div>
 </div>
 
@@ -261,25 +261,25 @@ order: 01
     <div class="usa-color-short usa-color-cool-blue">
     </div>
       <p class="usa-color-hex">#205493</p>
-      <p class="usa-color-name">cool-blue</p>
+      <p class="usa-color-name">$color-cool-blue</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-cool-blue-light">
     </div>
       <p class="usa-color-hex">#4773aa</p>
-      <p class="usa-color-name">cool-blue-light</p>
+      <p class="usa-color-name">$color-cool-blue-light</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-cool-blue-lighter">
     </div>
       <p class="usa-color-hex">#8ba6ca</p>
-      <p class="usa-color-name">cool-blue-lighter</p>
+      <p class="usa-color-name">$color-cool-blue-lighter</p>
   </div>
   <div class="color-small">
     <div class="usa-color-short usa-color-cool-blue-lightest">
     </div>
       <p class="usa-color-hex">#dce4ef</p>
-      <p class="usa-color-name">cool-blue-lightest</p>
+      <p class="usa-color-name">$color-cool-blue-lightest</p>
   </div>
 </div>
 
@@ -290,7 +290,7 @@ order: 01
     <div class="usa-color-short usa-color-focus">
     </div>
     <p class="usa-color-hex">#3e94cf</p>
-    <p class="usa-color-name">focus</p>
+    <p class="usa-color-name">$color-focus</p>
   </div>
 </div>
 
@@ -299,6 +299,6 @@ order: 01
     <div class="usa-color-short usa-color-visited">
     </div>
     <p class="usa-color-hex">#4c2c92</p>
-    <p class="usa-color-name">visited</p>
+    <p class="usa-color-name">$color-visited</p>
   </div>
 </div>


### PR DESCRIPTION
## Description
Instead of using `primary` use `$color-primary` to be more explicit about what the exact SASS variable is that is being used. This just involved adding `$color-` to the variable names that already existed. 

### Screenshot after adding specific variable names
<img width="1001" alt="screen shot 2017-05-23 at 10 03 05 am" src="https://cloud.githubusercontent.com/assets/1449852/26357983/0d5ac92a-3f9f-11e7-843e-b734fd884896.png">