### PR TITLE
removing tabindexes on content

### DIFF
--- a/_components/page-templates/template-docs.html
+++ b/_components/page-templates/template-docs.html
@@ -116,7 +116,7 @@ layout: demo-page
       </div>
     </header>
     <div class="usa-overlay"></div>
-    <main class="usa-grid usa-section usa-content usa-layout-docs" id="main-content" tabindex="-1">
+    <main class="usa-grid usa-section usa-content usa-layout-docs" id="main-content">
       <aside class="usa-width-one-fourth usa-layout-docs-sidenav">
         <ul class="usa-sidenav-list">
           <li>
@@ -211,4 +211,3 @@ layout: demo-page
     <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
     </body>
   </html>
-

--- a/_components/page-templates/template-landing.html
+++ b/_components/page-templates/template-landing.html
@@ -145,7 +145,7 @@ layout: demo-page
       </nav>
     </header>
     <div class="usa-overlay"></div>
-    <main id="main-content" tabindex="-1">
+    <main id="main-content">
       <section class="usa-hero">
         <div class="usa-grid">
           <div class="usa-hero-callout usa-section-dark">

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<main id="main-content" tabindex="-1">
+<main id="main-content">
   {% if page.hero %}
   <section class="usa-hero">
     <div class="usa-grid">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ category: What’s new
   </ul>
 </aside>
 
-<main id="main-content" class="main-content" tabindex="-1">
+<main id="main-content" class="main-content">
   <div class="styleguide-content usa-content">
   {% if page.collection == 'posts' %}
     {% include post.html post=page %}

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -10,7 +10,7 @@ layout: default
   {% endif %}
 </aside>
 
-<main id="main-content" class="main-content" tabindex="-1">
+<main id="main-content" class="main-content">
 
   <div class="styleguide-content usa-content">
     <header>


### PR DESCRIPTION
When v1.1 was released, `tabindex="-1"` was added to many sections on the docs site to ensure the skipnav functionality was working correctly. This is no longer necessary given the javascript rewrites in 1.2 and will no longer create focus outlines around content when a user is using a mouse to navigate and clicking around on the content. 

(meaning this won't happen anymore) 
![screen shot 2017-05-30 at 4 20 15 pm](https://cloud.githubusercontent.com/assets/776987/26605566/301ef764-4554-11e7-931d-ad1862e2fbf7.png)
