### PR TITLE
Add USDA Case Study

### DIFF
--- a/_posts/2017-06-06-usda-case-study.md
+++ b/_posts/2017-06-06-usda-case-study.md
@@ -1,0 +1,41 @@
+---
+title: How the USDA team uses the U.S. Web Design Standards
+tags:
+- web design standards
+- design
+- case study
+- design
+---
+The U.S. Web Design Standards team continues to sit down with various agencies who are using the Standards. In this third post in our series, we met with the team at the U.S. Department of Agriculture (USDA) and learned how they used the Standards to refresh [USDA.gov](https://usda.gov).
+
+**Standards team:** How did your team find out about the Web Design Standards?
+
+**USDA Team:** Our team is subscribed to the listservs and it’s one of the ways we heard about the Standards as they were being developed. Before using them on the USDA site we tried using the Standards on a smaller site we were building for new farmers. By the time we began our redesign work of [USDA.gov](https://usda.gov) we were familiar with, and ready to adopt, the Standards. Since they had worked well in the past we decided to use them for the project.
+
+**Standards team:** What other frameworks did you consider?
+
+**USDA Team:** We didn’t spend a lot of time looking at other frameworks because we already liked the colors, fonts and other components of the Standards. We did spend some time looking at industry sites, as well as, evaluating other sites using the Standards to see how they were implemented.
+
+**Standards team:** Did you encounter any resistance in your adoption of the Standards?
+
+**USDA Team:** We didn’t have any issues getting buy-in for the main USDA site, because the look and feel of the New Farmers site we had built earlier was well received. There was no pushback and we received great feedback all the way around.
+
+**Standards team:** What were the benefits you gained? How much time or money did this save?
+
+**USDA Team:** We were able to save time and money by relying on the Standards. It was great to have everything provided for us, with the Standards, and we were able to just adapt things that were already there. The Standards helped streamline the design process for us, the files were easy to download and use, and our developers were able to easily review—and apply— the design specs for the new site.
+
+**Standards team:** How do you plan to use the Standards on future projects?
+
+**USDA Team:** We plan to be flexible with our agencies, and offices, and not force their hand in trying to get them to use the Standards. They may not have the time or resources to switch over to the new look and feel we’ve established and we understand that. However, as our agencies and offices begin working on new projects or redesigns for their own sites, we are pointing them to the U.S. Web Design Standards.
+
+**Standards team:** What could we offer to make adoption easier?
+
+**USDA Team:** From a design perspective, the components were perfectly packaged and easy to use. We had some questions around 508 accessibility compliance, on how agencies can adhere to the accessibility guidelines when applying the Standards, and we were able to work quickly to ensure these needs were met, as well.
+
+**Standards team:** What advice would you have for other agencies looking to adopt the Standards?
+
+**USDA Team:** The Standards are clean-cut. Palettes are there, fonts are there, everything is ready to go, so it sells itself. It’s just a matter of finding the right set that meets your needs. Everything is nicely packaged and accessible, which means you don’t need to step outside your team to implement them. The Standards make it easier for government sites to stay consistent, while still applying a great look and feel to your sites. They are a tremendous value to any agency working on a web project.
+
+---
+
+We’re looking to learn more [from agencies that have used the Standards](https://github.com/18F/web-design-standards/blob/staging/WHO_IS_USING_USWDS.md); if you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [uswebdesignstandards@gsa.gov](mailto:uswebdesignstandards@gsa.gov). You can also chat with the team in the new [public Slack channel for the Standards](https://chat.18f.gov/)!

--- a/_posts/2017-06-06-usda-case-study.md
+++ b/_posts/2017-06-06-usda-case-study.md
@@ -14,7 +14,7 @@ The U.S. Web Design Standards team continues to sit down with various agencies w
 
 **Standards team:** What other frameworks did you consider?
 
-**USDA Team:** We didn’t spend a lot of time looking at other frameworks because we already liked the colors, fonts and other components of the Standards. We did spend some time looking at industry sites, as well as, evaluating other sites using the Standards to see how they were implemented.
+**USDA Team:** We didn’t spend a lot of time looking at other frameworks because we already liked the colors, fonts, and other components of the Standards. We did spend some time looking at industry sites, as well as, evaluating other sites using the Standards to see how they were implemented.
 
 **Standards team:** Did you encounter any resistance in your adoption of the Standards?
 
@@ -38,4 +38,4 @@ The U.S. Web Design Standards team continues to sit down with various agencies w
 
 ---
 
-We’re looking to learn more [from agencies that have used the Standards](https://github.com/18F/web-design-standards/blob/staging/WHO_IS_USING_USWDS.md); if you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [uswebdesignstandards@gsa.gov](mailto:uswebdesignstandards@gsa.gov). You can also chat with the team in the new [public Slack channel for the Standards](https://chat.18f.gov/)!
+We’re looking to learn more [from agencies that have used the Standards](/getting-started/showcase/); if you’re interested in talking to us about your experience or have any feedback, feel free to send us an email at [uswebdesignstandards@gsa.gov](mailto:uswebdesignstandards@gsa.gov). You can also chat with the team in the new [public Slack channel for the Standards](https://chat.18f.gov/)!

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "nswatch": "^0.2.0",
     "politespace": "^0.1.4",
     "run-sequence": "^1.1.5",
-    "uswds": "1.2.0-rc1",
+    "uswds": "1.2.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uswds-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Website and documentation on using the U.S. Web Design Standards.",
   "scripts": {
     "federalist": "gulp build",


### PR DESCRIPTION
This adds the USDA case study and upgrades the standards site to 1.2.1

Preview the post [here](https://federalist-proxy-staging.app.cloud.gov/preview/18f/web-design-standards-docs/usda-casestudy/whats-new/updates/2017/06/06/usda-case-study/)