### PR TITLE
Add basic site crawler to find 404s, etc.

### DIFF
--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -30,7 +30,7 @@ lead: Use buttons to signal actions.
       <li><code>usa-button-big</code></li>
     </ul>
     <p>For example, a secondary button style would use the following code:
-    <code>&lt;a class="usa-button usa-button-secondary" href="/my-link"&gt;My button&lt;/a&gt;</code></p>
+    <code>&lt;a class="usa-button usa-button-secondary" href=&quot;/my-link"&gt;My button&lt;/a&gt;</code></p>
     <h4 class="usa-heading">Accessibility</h4>
     <ul class="usa-content-list">
       <li>Buttons should display a visible focus state when users tab to them.</li>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,10 +17,6 @@
   <link rel="canonical" href="{{ site.url }}{{ page.url }}">
   {% endif %}
 
-<!--[if lt IE 9]>
-  <script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
-<![endif]-->
-
 <!-- Favicons
 ================================================== -->
   <!-- 128x128 -->

--- a/_includes/ie-polyfill-scripts.html
+++ b/_includes/ie-polyfill-scripts.html
@@ -1,5 +1,0 @@
-<!--[if lt IE 9]>
-  <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/respond.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/rem.min.js"></script>
-<![endif]-->

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,3 @@
-{% include ie-polyfill-scripts.html %}
 {% include analytics.html %}
 {% include docs-scripts.html %}
 <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 5.1.0
+    version: 6
 
 dependencies:
   pre:

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -1,10 +1,10 @@
+const path = require('path');
+const fs = require('fs');
 const express = require('express');
 const Crawler = require("simplecrawler");
 const chalk = require('chalk');
 
 const app = express();
-
-app.use(express.static(`${__dirname}/../_site`));
 
 // These pages incorporate content from other files in other repos, so
 // they should be considered "second class" by the link checker, and
@@ -16,6 +16,7 @@ const WARNING_PAGES = [
 ];
 const WARNING = chalk.yellow('Warning');
 const ERROR = chalk.red('Error');
+const SITE_PATH = path.normalize(`${__dirname}/../_site`);
 
 function shouldFetch(item, referrerItem) {
   if (item.path.match(/&quot;/)) {
@@ -30,6 +31,13 @@ function shouldFetch(item, referrerItem) {
   }
 
   return true;
+}
+
+if (fs.existsSync(SITE_PATH)) {
+  app.use(express.static(SITE_PATH));
+} else {
+  console.log(`Please build the site before running me.`);
+  process.exit(1);
 }
 
 const listener = app.listen(() => {

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -3,7 +3,7 @@ const Crawler = require("simplecrawler");
 
 const app = express();
 
-app.use(express.static(`${__dirname}/_site`));
+app.use(express.static(`${__dirname}/../_site`));
 
 // These pages incorporate content from other files in other repos, so
 // they should be considered "second class" by the link checker, and

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const Crawler = require("simplecrawler");
+const chalk = require('chalk');
 
 const app = express();
 
@@ -13,6 +14,8 @@ const WARNING_PAGES = [
     '/whats-new/releases/',
     '/getting-started/showcase/all/',
 ];
+const WARNING = chalk.yellow('Warning');
+const ERROR = chalk.red('Error');
 
 function shouldFetch(item, referrerItem) {
   if (item.path.match(/&quot;/)) {
@@ -61,7 +64,7 @@ const listener = app.listen(() => {
       notFound.forEach(item => {
         const refs = referrers[item.url];
         const isWarning = refs.every(path => WARNING_PAGES.includes(path));
-        const label = isWarning ? 'Warning' : 'Error';
+        const label = isWarning ? WARNING : ERROR;
 
         console.log(`${label}: 404 for ${item.path}!`);
         console.log(`  ${refs.length} referrer(s) including at least:`,
@@ -75,7 +78,7 @@ const listener = app.listen(() => {
 
       WARNING_PAGES.forEach(path => {
         if (!(`${baseURL}${path}` in referrers)) {
-          console.log(`Error: ${path} was not visited!`);
+          console.log(`${ERROR}: ${path} was not visited!`);
           console.log(`  If this is not an error, please remove the path ` +
                       `from WARNING_PAGES.`);
           errors++;
@@ -86,9 +89,9 @@ const listener = app.listen(() => {
 
       console.log(`${errors} error(s) and ${warnings} warning(s) found.`);
       if (success) {
-        console.log(`Hooray!`);
+        console.log(chalk.green(`Hooray!`));
       } else {
-        console.log(`Alas.`);
+        console.log(chalk.red(`Alas.`));
       }
       process.exit(success ? 0 : 1);
     });

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -74,7 +74,7 @@ const listener = app.listen(() => {
         const isWarning = refs.every(path => WARNING_PAGES.includes(path));
         const label = isWarning ? WARNING : ERROR;
 
-        console.log(`${label}: 404 for ${item.path}!`);
+        console.log(`${label}: 404 for ${item.path}`);
         console.log(`  ${refs.length} referrer(s) including at least:`,
                     refs.slice(0, 5));
         if (isWarning) {

--- a/crawl.js
+++ b/crawl.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const Crawler = require("simplecrawler");
+
+const app = express();
+
+app.use(express.static(`${__dirname}/_site`));
+
+const listener = app.listen(() => {
+  const port = listener.address().port;
+  const crawler = new Crawler(`http://127.0.0.1:${port}/`);
+  const referrers = {};
+  let errors = 0;
+
+  crawler.maxDepth = 2;
+  crawler.interval = 1;
+  crawler.on("discoverycomplete", (item, resources) => {
+    resources.forEach(url => {
+      if (!(url in referrers)) {
+        referrers[url] = [];
+      }
+      referrers[url].push(item.path);
+    });
+  });
+  crawler.on("fetch404", (item, res) => {
+    const refs = referrers[item.url];
+    console.log(`404 for ${item.path}!`);
+    console.log(`  ${refs.length} referrer(s) including at least:`,
+                refs.slice(0, 5));
+    errors++;
+  });
+  crawler.on("complete", () => {
+    listener.close(() => {
+      const success = errors === 0;
+      console.log(`${errors} error(s) found.`);
+      if (success) {
+        console.log(`Hooray!`);
+      } else {
+        console.log(`Alas.`);
+      }
+      process.exit(success ? 0 : 1);
+    });
+  });
+  crawler.start();
+});

--- a/crawl.js
+++ b/crawl.js
@@ -11,7 +11,7 @@ const listener = app.listen(() => {
   const referrers = {};
   let errors = 0;
 
-  crawler.maxDepth = 2;
+  crawler.maxDepth = 3;
   crawler.interval = 1;
   crawler.on("discoverycomplete", (item, resources) => {
     resources.forEach(url => {

--- a/crawl.js
+++ b/crawl.js
@@ -11,6 +11,13 @@ const listener = app.listen(() => {
   const referrers = {};
   let errors = 0;
 
+  crawler.addFetchCondition((item, referrerItem, cb) => {
+    // If a URL's path contains a literal `&quot;` in it, then it's
+    // almost guaranteed to be a false-positive that's actually
+    // in an example snippet of HTML in the docs, so ignore it.
+    cb(null, !item.path.match(/&quot;/));
+  });
+
   crawler.maxDepth = 3;
   crawler.interval = 1;
   crawler.on("discoverycomplete", (item, resources) => {

--- a/crawl.js
+++ b/crawl.js
@@ -12,10 +12,20 @@ const listener = app.listen(() => {
   let errors = 0;
 
   crawler.addFetchCondition((item, referrerItem, cb) => {
-    // If a URL's path contains a literal `&quot;` in it, then it's
-    // almost guaranteed to be a false-positive that's actually
-    // in an example snippet of HTML in the docs, so ignore it.
-    cb(null, !item.path.match(/&quot;/));
+    let doFetch = true;
+
+    if (item.path.match(/&quot;/)) {
+      // If a URL's path contains a literal `&quot;` in it, then it's
+      // almost guaranteed to be a false-positive that's actually
+      // in an example snippet of HTML in the docs, so ignore it.
+      doFetch = false;
+    } else if (referrerItem.path.match(/\.js$/)) {
+      // Just ignore anything gleaned from JS files for now, it's too likely
+      // that it's a false positive.
+      doFetch = false;
+    }
+
+    cb(null, doFetch);
   });
 
   crawler.maxDepth = 3;

--- a/crawl.js
+++ b/crawl.js
@@ -28,7 +28,7 @@ const listener = app.listen(() => {
     cb(null, doFetch);
   });
 
-  crawler.maxDepth = 3;
+  crawler.maxDepth = 99;
   crawler.interval = 1;
   crawler.on("discoverycomplete", (item, resources) => {
     resources.forEach(url => {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "browserify": "^13.0.0",
     "del": "^2.2.0",
+    "express": "^4.15.3",
     "gulp": "^3.9.0",
     "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.6.0",
@@ -81,6 +82,7 @@
     "nswatch": "^0.2.0",
     "politespace": "^0.1.4",
     "run-sequence": "^1.1.5",
+    "simplecrawler": "^1.1.3",
     "uswds": "1.2.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "homepage": "https://github.com/18F/web-design-standards-docs#readme",
   "dependencies": {
     "browserify": "^13.0.0",
+    "chalk": "^1.1.3",
     "del": "^2.2.0",
     "express": "^4.15.3",
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postinstall": "bundle",
     "prestart": "gulp build",
     "start": "bundle exec jekyll serve --drafts --future",
-    "test": "npm run lint",
+    "test": "npm run lint && npm run crawl",
+    "crawl": "node config/crawl.js",
     "watch": "nswatch"
   },
   "watch": {

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -116,7 +116,7 @@ node_modules/uswds/dist/css/uswds.css
 
 If you’re using another framework or package manager that doesn’t support NPM, you can find the source files in this repository and use them in your project. Otherwise, we recommend that you follow the [download instructions](#download). Please note that the core team [isn’t responsible for all frameworks’ implementations](https://github.com/18F/web-design-standards/issues/877).
 
-If you’re interested in maintaining a package that helps us distribute the U.S. Web Design Standards, the project’s build system can help you create distribution bundles to use in your project. Please read our [contributing guidelines](CONTRIBUTING.md#building-the-project-locally-with--gulp-) to locally build distributions for your framework or package manager.
+If you’re interested in maintaining a package that helps us distribute the U.S. Web Design Standards, the project’s build system can help you create distribution bundles to use in your project. Please read our [contribution guidelines][] to locally build distributions for your framework or package manager.
 
 ### Need installation help?
 
@@ -200,6 +200,8 @@ The Standards also meet the [WCAG 2.0 AA accessibility guidelines](https://www.w
 
 ## Contribution guidelines
 
-We’re so glad you’re thinking about contributing to the Standards! You can find our complete [contribution guidelines](https://github.com/18F/web-design-standards/blob/develop/CONTRIBUTING.md) in our repo — please review them before submitting your contribution.
+We’re so glad you’re thinking about contributing to the Standards! You can find our complete [contribution guidelines][] in our repo — please review them before submitting your contribution.
 
 If you have any questions about these guidelines (or the Standards, more generally), don’t hesitate to [email us](mailto:uswebdesignstandards@gsa.gov) — we’ll get back to you within 48 hours.
+
+[contribution guidelines]: https://github.com/18F/web-design-standards/blob/develop/CONTRIBUTING.md


### PR DESCRIPTION
This is a **work-in-progress** attempt to fix #269, or at least part of it.

## Instructions

1. Generate the site using `jekyll build`.  The `_site` folder should now contain the latest version of the site.

2. Run `npm run crawl`.  It will let you know if it found any errors.

## Notes

I decided to use [`node-simplecrawler`](https://github.com/cgiffard/node-simplecrawler) because I've had experience using it in the past, and it seems reasonably fast and extensible.

Unlike https://github.com/18F/content-guide/pull/132, I decided not to go with [`html-proofer`](https://github.com/gjtorikian/html-proofer) because it's Ruby-based, and I don't have a ton of experience with Ruby. I also heard rumors that we might consider migrating this site from Jekyll to Hugo; if that happens, we would likely remove Ruby entirely from this project, so I figured node might be a safer long-term option. We can always switch, though!

## To do

Some of these can be filed as separate issues and dealt with in separate PRs.

- [x] Consider making the crawler crawl more than just the index page and all the immediate resources it links to.
- [x] Fix 404s reported by the tool, or log warnings if the 404s come from external sources. Currently these seem to be:
  * ~~All the JS scripts referenced by `ie-polyfill-scripts.html`.~~
  * ~~`html5shiv.js`, which is in an IE-only comment in `head.html`.~~
  * ~~In the developer's guide, there's a broken link to `CONTRIBUTING.md`.~~
- [x] Run the crawler as part of `npm test` (and therefore during CI).
- [x] Don't report errors until we're done w/ the crawl; this way our list of referrers is accurate.
