### PR TITLE
Use scss-lint's failReporter

### DIFF
--- a/config/gulp/sass.js
+++ b/config/gulp/sass.js
@@ -37,7 +37,8 @@ gulp.task('scss-lint', function (done) {
     ])
     .pipe(linter({
       config: '.scss-lint.yml',
-    }));
+    }))
+    .pipe(linter.failReporter('E'));
 
 });
 


### PR DESCRIPTION
This fixes #322. For now we just fail on errors, not warnings; since warnings are already raised by scss-lint, I figure we can start with errors, and then move to warnings if we want, once we clean them up first.