### PR TITLE
Remove alt text for decorative images in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,17 +44,17 @@
       <div class="usa-footer-contact-links usa-width-one-third">
         <h5>Find an issue or have a feature request?</h5>
         <a href="{{ site.repos[0].url }}/issues/new" class="usa-button cta">
-          <img src="{{ site.baseurl }}/img/logo-github.png" alt="GitHub logo">
+          <img src="{{ site.baseurl }}/img/logo-github.png" alt="">
           Ask questions on GitHub
         </a>
         <h5>Need help troubleshooting?</h5>
         <a href="https://chat.18f.gov/" class="usa-button cta">
-          <img src="{{ site.baseurl }}/img/logo-slack.png" alt="Slack logo">
+          <img src="{{ site.baseurl }}/img/logo-slack.png" alt="">
           Join our Slack Channel
         </a>
         <h5>Want to hire or contact us?</h5>
         <a href="mailto:uswebdesignstandards@gsa.gov" class="usa-button cta">
-          <img src="{{ site.baseurl }}/img/logo-email.png" alt="Email logo">
+          <img src="{{ site.baseurl }}/img/logo-email.png" alt="">
           Send us an email
         </a>
       </div>


### PR DESCRIPTION
When examining the new homepage design in #255 with a screen reader, I noticed that the decorative logos in the footer have alt text, which is distracting because they're decorative--the text of the links they're embedded in already provide enough context for visually impaired users to understand where following them will go.
