### PR TITLE
Set aria-label of site logo to "USWDS home"

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -5,7 +5,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo site-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="{{ site.baseurl }}/" title="Home" aria-label="Home">
+        <a href="{{ site.baseurl }}/" title="Home" aria-label="{{ site.title }} home">
           {{ site.title }}
         </a>
       </em>


### PR DESCRIPTION
When performing an accessibility audit of a different site with @nickbristow last week, he called out the site's logo link, which had an `aria-label` of just "Home", while the visual equivalent had the name of the site on it.  He said that the screen reader representation should be either the site name or the site name followed by "home".

When using a screen reader to examine the new home page in #255 I noticed that this site has the same issue.

Personally I prefer to follow the site name by "home" because it additionally identifies exactly *where* the link takes you, which is obvious from its visual placement on the page, but may not be obvious to users of ATs.

@nickbristow do you think this change makes sense, or did I misinterpret your guidance during our audit of that NSF site?
