### PR TITLE
Fix paths to SCSS files mentioned in docs.

### DIFF
--- a/_components/typography/03-typesetting.md
+++ b/_components/typography/03-typesetting.md
@@ -20,7 +20,7 @@ order: 03
     <h4 class="usa-heading">Implementation</h4>
     <p>To get the max-width on body text, add the class <code>usa-content</code> to your document. Use at the specificity that best suits your project's needs.</p>
     <p>Lists must use <code>usa-content-list</code> for the above.</p>
-    <p>You can change the max-width value <code>$text-max-width</code> in <code>assets/_scss/core/<wbr>variables.scss</code>.</p>
+    <p>You can change the max-width value <code>$text-max-width</code> in <code>src/stylesheets/core/<wbr>_variables.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <ul class="usa-content-list">
       <li>Alignment: Type set flush left provides the eye a constant starting point for each line, making text easier to read.</li>

--- a/_components/typography/05-lists.md
+++ b/_components/typography/05-lists.md
@@ -18,7 +18,7 @@ order: 05
   </button>
   <div id="list-docs" class="usa-accordion-content">
     <h4 class="usa-heading">Implementation</h4>
-    <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>assets/_scss/core/<wbr>utilities.scss</code>.</p>
+    <p>Lists are styled by default. For unstyled lists, use either the <code>usa-unstyled-list</code> class or unstyled list mixin: <code>@include unstyled-list;</code>. Both are located in <code>src/stylesheets/core/<wbr>_utilities.scss</code>.</p>
     <h4 class="usa-heading">Usability</h4>
     <h5>When to use</h5>
     <ul class="usa-content-list">


### PR DESCRIPTION
Some of our documentation mentions actual `.scss` files, but the files no longer exist because the USWDS directory structure was refactored at some point after the docs were written. This fixes that.