### PR TITLE
Add incremental_regeneration_fixer plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,13 @@ future: true
 
 encoding: utf-8
 
+incremental_regeneration_fixer:
+  interdependent_files:
+    - "_components/colors/*"
+    - "_components/form-controls/*"
+    - "_components/form-templates/*"
+    - "_components/typography/*"
+
 jekyll_get:
   - data: releases
     json: 'https://api.github.com/repos/18F/web-design-standards/releases'

--- a/_plugins/incremental_regeneration_fixer.rb
+++ b/_plugins/incremental_regeneration_fixer.rb
@@ -1,0 +1,42 @@
+module IncrementalRegenerationFixer
+  def IncrementalRegenerationFixer.init(site)
+    if site.regenerator.disabled?
+      return
+    end
+
+    # This is a fix for the following bug:
+    #
+    #   https://github.com/jekyll/jekyll/issues/4112
+    #
+    # To work around it, we'll remember groups of interdependent files;
+    # if any of the files in a group changes, we'll make sure to
+    # regenerate *all* the files in that group.
+    interdependent_files = []
+
+    config = site.config['incremental_regeneration_fixer']
+
+    for glob in config['interdependent_files']
+      group = Dir["#{site.source}/#{glob}"]
+      if group.length == 0
+        raise ("The path '#{glob}' contains no files! Please fix " +
+               "interdependent_files in your site's _config.yml.")
+      end
+      interdependent_files << group
+    end
+
+    for group in interdependent_files
+      for srcfile in group
+        if site.regenerator.modified? srcfile
+          for dependent_file in group
+            site.regenerator.force dependent_file
+          end
+          break
+        end
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register :site, :post_read do |site|
+  IncrementalRegenerationFixer.init(site)
+end


### PR DESCRIPTION
On my system, Jekyll takes upwards of 8 seconds to rebuild itself without incremental regeneration, which is frustrating when I'm trying to rapidly iterate on content.  Enabling [incremental regeneration](https://jekyllrb.com/docs/configuration/#incremental-regeneration) reduces it to 2.5 seconds, which is bearable, but https://github.com/jekyll/jekyll/issues/4112 prevents some of our sections--notably "colors", "typography", "form controls", and "form templates"--from regenerating properly. Changes to these sections result in either no visible changes on the site, or raw markdown/liquid template source being present in the site.

## Notes

* When trying to figure out what I could do to speed up build time, I enabled liquid profiling via Jekyll's `--profile` option and noticed that almost half our build time is taken up by our nav bar rendering code. I tried using [jekyll-include-cache](https://github.com/benbalter/jekyll-include-cache) to speed things up, but our nav bar code uses some global variables like `_current` to track state, which complicated things, so I decided not to pursue this solution, though we can revisit it later.

* I learned about the API of Jekyll's `Site` class by reading its [`site.rb`](https://github.com/jekyll/jekyll/blob/14f0db9dcc10bd3c80c4f1f9a69ef220a2bd9102/lib/jekyll/site.rb).

* I learned about the API of Jekyll's `Regenerator` class by reading its [`regenerator.rb`](https://github.com/jekyll/jekyll/blob/27ed81547b12d28a60c51961b82a5723981feb7d/lib/jekyll/regenerator.rb).
