### PR TITLE
Fix relative links in external markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,6 @@ gem 'rouge', '1.9'
 gem 'scss_lint', require: false
 
 gem 'jekyll-compose', group: [:jekyll_plugins]
+
+gem 'rspec-core'
+gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
+    diff-lcs (1.3)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
     hash-joiner (0.0.7)
@@ -44,6 +45,12 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
     rouge (1.9.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     safe_yaml (1.0.4)
     sass (3.4.23)
     scss_lint (0.50.2)
@@ -62,7 +69,9 @@ DEPENDENCIES
   open-uri-cached
   redcarpet
   rouge (= 1.9)
+  rspec-core
+  rspec-expectations
   scss_lint
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/_plugins/uswds.rb
+++ b/_plugins/uswds.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module USWDS
 
   # Return true if a == b, false otherwise:
@@ -36,6 +38,16 @@ module USWDS
       .first
   end
 
+  def remove_relative_links(content)
+    content.gsub(/\<a href="(?!https?:)([^"]+)"\>(.+?)\<\/a\>/, '\2')
+  end
+
+  def absolutify_links(content, base_url)
+    content.gsub(/href="(?!https?:)([^"]+)"/){
+      absolute = URI.join(base_url, $1)
+      "href=\"#{absolute}\""
+    }
+  end
 end
 
 Liquid::Template.register_filter(USWDS)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "bundle",
     "prestart": "gulp build",
     "start": "bundle exec jekyll serve --drafts --future",
-    "test": "npm run lint && npm run crawl",
+    "test": "npm run lint && npm run crawl && bundle exec rspec",
     "crawl": "node config/crawl.js",
     "watch": "nswatch"
   },

--- a/pages/getting-started/code-guidelines.md
+++ b/pages/getting-started/code-guidelines.md
@@ -6,4 +6,4 @@ category: Getting started
 lead: 
 ---
 
-{{ site.data.contributing.decoded }}
+{{ site.data.contributing.decoded | markdownify | absolutify_links: site.data.contributing.html_url }}

--- a/pages/getting-started/showcase-all.md
+++ b/pages/getting-started/showcase-all.md
@@ -6,4 +6,4 @@ category: Getting started
 lead: Below are a list of website and applications currently using the U.S. Web Design Standards. If your project is currently using the Standards and you do not see it on this list, please feel free to [submit a pull request](https://github.com/18F/web-design-standards/pulls/) or email the core team at [uswebdesignstandards@gsa.gov](mailto:uswebdesignstandards@gsa.gov).
 ---
 ##Sites using the U.S. Web Design Standards
-{{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' }}
+{{ site.data.standards-sites.decoded | newline_to_br | split: '<br />' | where_exp: 'line', 'line contains "- ["' | join: '<br />' | markdownify | absolutify_links: site.data.standards-sites.html_url }}

--- a/pages/whats-new/releases.md
+++ b/pages/whats-new/releases.md
@@ -23,7 +23,7 @@ Have suggestions for a new feature or bug fix? [Open an issue](https://github.co
 <p class="site-subheading">{{ release.published_at | date: "%B %d, %Y" }}</p>
 
 {% assign id_replace = 'id="v%-' | replace: '%', release.name %}
-{{ release.body | markdownify | replace: 'id="', id_replace }}
+{{ release.body | markdownify | replace: 'id="', id_replace | remove_relative_links }}
 
 <hr>
 {% endfor %}

--- a/spec/uswds_spec.rb
+++ b/spec/uswds_spec.rb
@@ -1,0 +1,32 @@
+require 'liquid'
+require './_plugins/uswds'
+
+include USWDS
+
+RSpec.describe USWDS do
+  describe 'absolutify_links' do
+    it 'replaces relative links with absolute ones' do
+      html = 'hello <a href="blah">there</a>'
+      expect(absolutify_links(html, "http://boop")).to eq(
+        'hello <a href="http://boop/blah">there</a>'
+      )
+    end
+
+    it 'does not affect links that are already absolute' do
+      html = 'hi <a href="http://boink">a</a> <a href="https://boink">b</a>'
+      expect(absolutify_links(html, "http://boop")).to eq(html)
+    end
+  end
+
+  describe 'remove_relative_links' do
+    it 'removes relative links, but leaves their inner content behind' do
+      html = 'hello <a href="blah">there</a> <a href="flarg"><i>human</i></a>'
+      expect(remove_relative_links(html)).to eq('hello there <i>human</i>')
+    end
+
+    it 'does not affect links that are already absolute' do
+      html = 'hi <a href="http://boink">a</a> <a href="https://boink">b</a>'
+      expect(remove_relative_links(html)).to eq(html)
+    end
+  end
+end


### PR DESCRIPTION
This fixes #324 by adding two new liquid filters:

* `absolutify_links` converts all relative links into absolute links with the given base URL. This is used in `code-guidelines.md` and `showcase-all.md`.
* `remove_relative_links` simply un-hyperlinks any relative links. We're using it in `releases.md` because GitHub is doing special things to hyperlink relative links that aren't easy for us to reproduce, so it's easier to just un-hyperlink the handful of relative links that exist on the page.

It also adds an rspec-based test suite to the project. Aside from ensuring code quality, it was also *much* faster for me to rapidly iterate on the new liquid filters using TDD than it was to wait on the 2.5 second incremental build time every time I changed code. It also allowed me to work around #272, whereby changing my code too fast could trigger GitHub's API rate limiting.

## How to manually verify this works

* For `releases.md`, our [notes for 1.2.0-rc1](https://github.com/18F/web-design-standards/releases/tag/v1.2.0-rc1) contain a relative link around the text `v1.x compatibility unit tests`. This text should no longer be hyperlinked when viewed on the site.
* For `code-guidelines.md`, there's a relative link around the text `unit test suite` in our [`CONTRIBUTING.md`](https://github.com/18F/web-design-standards/blob/develop/CONTRIBUTING.md) that should no longer 404 when viewed on the site.
* For `showcase-all.md`, the link to `National Archives and Records Administration` is actually an accidental relative link that will be fixed by https://github.com/18F/web-design-standards/pull/2000. Until that gets merged, though, this is the only relative link on that page, and viewing it on the site should take you to a GitHub 404 rather than a 404 on the standards docs site. That said, if we're really confident we'll never have legitimate relative links in `WHO_IS_USING_USWDS.md`, we can remove the link absolutification on this particular page.
