### PR TITLE
Support GitHub access tokens and cache API results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 npm-debug.log
 .bundle/
 assets/
+.jekyll_get_cache/

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'json'
 gem 'redcarpet'
-gem 'hash-joiner'
 gem 'open-uri-cached'
 gem 'jekyll-redirect-from'
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ may want to
 [create an access token](https://github.com/blog/1509-personal-api-tokens)
 and assign it to your `GITHUB_ACCESS_TOKEN` environment variable.
 
+The dynamic content is stored in the `.jekyll_get_cache` directory and
+won't be re-fetched once it's cached there. However, this means that your
+data can get stale over time, so if you want to ensure that your site
+is using the very latest data, you'll want to clear the cache by running:
+
+```
+rm -rf .jekyll_get_cache
+```
+
 ## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md). These guidelines are directions for opening issues and submitting pull requests, and they also detail the coding and design standards we follow.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ https://federalist.fr.cloud.gov/preview/18f/web-design-standards-docs/develop/
 
 See the [`_posts` directory](_posts/#readme) for instructions on adding updates.
 
+### Dynamic content
+
+Some of the content on the documentation site is dynamically fetched from
+GitHub. If you want to ensure that its API won't rate-limit you, you
+may want to
+[create an access token](https://github.com/blog/1509-personal-api-tokens)
+and assign it to your `GITHUB_ACCESS_TOKEN` environment variable.
+
 ## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md). These guidelines are directions for opening issues and submitting pull requests, and they also detail the coding and design standards we follow.

--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,10 @@ jekyll_get:
     json: 'https://api.github.com/repos/18F/web-design-standards/releases'
   - data: contributing
     json: 'https://api.github.com/repos/18F/web-design-standards/contents/CONTRIBUTING.md'
+    decode_content: true
   - data: standards-sites
     json: 'https://api.github.com/repos/18F/web-design-standards/contents/WHO_IS_USING_USWDS.md'
+    decode_content: true
 
 repos:
 - name: U.S. Web Design Standards

--- a/_plugins/jekyll_get.rb
+++ b/_plugins/jekyll_get.rb
@@ -8,6 +8,26 @@ module Jekyll_Get
     safe true
     priority :highest
 
+    def decode_content(source)
+      encoding = source['encoding']
+      target_content = source['content']
+      if encoding == 'base64'
+        source['decoded'] = Base64.decode64(target_content).force_encoding(Encoding::UTF_8)
+      else
+        source['decoded'] = target_content
+      end
+    end
+
+    def get_final_url(url)
+      if url.start_with? "https://api.github.com/"
+        access_token = ENV['GITHUB_ACCESS_TOKEN']
+        if access_token
+          return "#{url}?access_token=#{access_token}"
+        end
+      end
+      url
+    end
+
     def generate(site)
       config = site.config['jekyll_get']
       if !config
@@ -18,20 +38,17 @@ module Jekyll_Get
       end
       config.each do |d|
         name_of_target = d['data']
+        url = d['json']
         begin
           target = site.data[name_of_target]
-          source = JSON.load(open(d['json']))
+          source = JSON.load(open(get_final_url(url)))
           if target
             HashJoiner.deep_merge target, source
           else
             site.data[name_of_target] = source
           end
-          encoding = site.data[name_of_target]['encoding']
-          target_content = site.data[name_of_target]['content']
-          if encoding == 'base64'
-            site.data[name_of_target]['decoded'] = Base64.decode64(target_content).force_encoding(Encoding::UTF_8)
-          else
-            site.data[name_of_target]['decoded'] = target_content
+          if d['decode_content']
+            decode_content site.data[name_of_target]
           end
           if d['cache']
             data_source = (site.config['data_source'] || '_data')
@@ -40,7 +57,8 @@ module Jekyll_Get
               file << JSON.generate(site.data[name_of_target])
             end
           end
-        rescue
+        rescue => e
+          print "jekyll_get: error fetching #{url}: #{e}\n"
           next
         end
       end


### PR DESCRIPTION
This fixes #272 by authenticating with GitHub if the `GITHUB_ACCESS_TOKEN` environment variable is set.

## Notes

* jekyll_get no longer fails *silently*; it now at least logs an error message.
* It turned out that the fetching of the release notes was throwing an exception, because it was trying to decode the `content` key which didn't exist. I added another configuration parameter to each source called `decode_content` which specifies whether to attempt this decoding or not.
* We now follow the lead of https://github.com/18F/jekyll-get/pull/16 and *always* use cached data if it's available. Unlike that PR, we also always cache our data, because there doesn't seem any reason not to (and making it optional just introduces more branching logic which complicates the code).

## To do (optional)

If we merge this PR, the following should either be fixed now or filed as issues to be addressed later.

- [ ] I'd really like to add at least a few unit tests to this, at least for the stuff that's easy to test, but the unit test framework was added in #336, which hasn't been merged yet.
- [x] I think we should incorporate https://github.com/18F/jekyll-get/pull/16 and load the cached JSON data if it exists. Aside from lowering the barrier to entry for developers by not making it _quite_ so necessary for them to set `GITHUB_ACCESS_TOKEN`, it will also speed up incremental builds by around 0.5 seconds. We should also document it in the readme so developers don't get confused if they notice stale data on their local server, and so they know how to clear the cache if needed.
