### PR TITLE
Document validator component (take 2)

### DIFF
--- a/_components/form-controls/06-validation.md
+++ b/_components/form-controls/06-validation.md
@@ -1,0 +1,43 @@
+---
+title: Validation
+parent: Form controls
+maturity: alpha
+order: 06
+lead: Stating validation requirements up front, with live feedback, means users won't be left guessing.
+---
+
+{% include code/preview.html component="validation" %}
+{% include code/accordion.html component="validation" %}
+<div class="usa-accordion-bordered">
+  <button class="usa-button-unstyled usa-accordion-button"
+      aria-expanded="true" aria-controls="validation-docs">
+    Documentation
+  </button>
+  <div id="validation-docs" aria-hidden="false" class="usa-accordion-content">
+    <h4 class="usa-heading">Guidance</h4>
+    <ul class="usa-content-list">
+      <li>Input fields which have custom validation logic can automatically
+        provide helpful feedback to users if they are assigned a
+        <code>data-validation-element</code> attribute set to a
+        CSS selector that uniquely identifies a <code>.usa-checklist</code>,
+        e.g. <code>data-validation-element="#validate-code"</code>.</li>
+      <li>
+        For each kind of validation you'd like to provide feedback on:
+        <ol>
+          <li>Come up with a name for the validator, e.g.
+            <code>uppercase</code>. It shouldn't have any spaces in it.</li>
+          <li>On one of the list elements in the <code>.usa-checklist</code>,
+            set the <code>data-validator</code> attribute to the
+            name of the validator, e.g. <code>data-validator="uppercase"</code>.
+            This is the list item that will appear "checked" when the
+            validator's condition is met.</li>
+          <li>On the input field, add a field called
+            <code>data-validate-<em>validator name</em></code> and set
+            its value to a <a href="https://regexone.com/">regular
+            expression</a> that represents whether the validator's
+            condition is met, e.g. <code>data-validate-uppercase="[A-Z]"</code>.</li>
+        </ol>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/_components/form-controls/form-controls.md
+++ b/_components/form-controls/form-controls.md
@@ -18,6 +18,8 @@ subnav:
   href: '#radio-buttons'
 - text: Date input
   href: '#date-input'
+- text: Validation
+  href: '#validation'
 ---
 
 {% include accessibility.html %}

--- a/_components/form-templates/04-password-reset-form.md
+++ b/_components/form-templates/04-password-reset-form.md
@@ -25,6 +25,8 @@ lead: A standard template for resetting a password
     <h5>Guidance</h5>
     <ul class="usa-content-list">
       <li>If users need a password to access your site, they will forget that password and need a way to reset it.</li>
+      <li>For guidance on the technical details of validation, see the
+        <a href="/components/form-controls/#validation">validation documentation</a>.</li>
       <li>State any password requirements (for example, “Must include one capital letter”) up front. Don’t leave users guessing about password requirements, only to hit them with an error message later.</li>
       <li>The requirements shown above are just provided as an example and should not be taken as recommendations.</li>
     </ul>

--- a/_includes/code/components/password-reset.html
+++ b/_includes/code/components/password-reset.html
@@ -18,7 +18,6 @@
     <label for="new-password">New password</label>
     <input id="new-password" name="password" type="password"
       aria-describedby="validate-password-reset"
-      class="js-validate_password"
       data-validate-length=".{8,}"
       data-validate-uppercase="[A-Z]"
       data-validate-numerical="\d"

--- a/_includes/code/components/validation.html
+++ b/_includes/code/components/validation.html
@@ -1,0 +1,24 @@
+<form class="usa-form">
+  <fieldset>
+    <legend class="usa-drop_text">Enter a code</legend>
+
+    <div class="usa-alert usa-alert-info">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Codes must:</h3>
+      </div>
+      <ul class="usa-checklist" id="validate-code">
+        <li data-validator="uppercase">Have at least 1 uppercase character</li>
+        <li data-validator="numerical">Have at least 1 numerical character</li>
+      </ul>
+    </div>
+
+    <label for="code">Code</label>
+    <input id="code" name="code" type="text"
+      aria-describedby="validate-code"
+      data-validate-uppercase="[A-Z]"
+      data-validate-numerical="\d"
+      data-validation-element="#validate-code">
+
+    <input type="submit" value="Submit code">
+  </fieldset>
+</form>


### PR DESCRIPTION
~~**This PR is currently against #334 because I needed that PR's code to quickly iterate on this PR. However, if absolutely necessary, we can merge this code without merging #334.**~~

This attempts to fix https://github.com/18F/web-design-standards/issues/1432.

> ![validation](https://user-images.githubusercontent.com/124687/27869460-05f2e078-616e-11e7-9e72-e0e4f81254fe.png)

## Notes

* I wanted to link to some kind of documentation on regular expressions because I'm not sure all our readers will necessarily know what they are.  For now I've linked to https://regexone.com/, but we can either link to a different site or remove the link altogether.

* I also removed the mention of `.js-validate_password` in the code, fixing this repo's side of https://github.com/18F/web-design-standards/issues/1998.