### PR TITLE
Run aXe on a few pages during CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You will need to have the following installed on your machine before following t
 1. Ruby v2.2.2+, [Installation guides](https://www.ruby-lang.org/en/documentation/installation/)
 1. Node v4.2.3+, [Installation guides](https://nodejs.org/en/download/)
 1. Bundler v1.12.3+, [Installation guides](http://bundler.io/v1.13/guides/using_bundler_in_application.html#getting-started---installing-bundler-and-bundle-init)
-
+1. Chrome v59 or higher (v60 if on Windows)
 
 ### Building the documentation with gulp
 
@@ -43,7 +43,7 @@ Here are a few other utility commands you may find useful:
 
 - `npm run lint`: Runs `eslint` and `sass-lint` against JavaScript and Sass files.
 
-- `npm test`: Runs `npm run lint` and can also be used to run any tests.
+- `npm test`: Runs all tests and linters.
 
 - `npm run watch`: Runs a series of commands that watches for any changes in both the Standards node module and the root level asset folders in this repo.
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,11 @@ machine:
 dependencies:
   pre:
     - bundle install
+    # https://discuss.circleci.com/t/using-the-latest-version-of-chrome-on-circleci/871/4
+    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - sudo dpkg -i google-chrome.deb
+    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+    - rm google-chrome.deb
 
 test:
   pre:

--- a/config/run-axe.js
+++ b/config/run-axe.js
@@ -8,6 +8,11 @@ const runServer = require('./static-server');
 
 const REMOTE_CHROME_URL = process.env['REMOTE_CHROME_URL'];
 const AXE_JS = fs.readFileSync(__dirname + '/../node_modules/axe-core/axe.js');
+const PAGES = [
+  '/',
+  '/page-templates/landing/',
+  '/page-templates/docs/',
+];
 
 function launchChromeLocally(headless=true) {
   return chromeLauncher.launch({
@@ -48,15 +53,26 @@ let getChrome = REMOTE_CHROME_URL ? getRemoteChrome : launchChromeLocally;
 
 Promise.all([runServer(), getChrome()]).then(([server, chrome]) => {
   const chromeHost = chrome.host || 'localhost';
+  console.log(`Static file server is listening at ${server.url}.`);
   console.log(`Chrome is debuggable on http://${chromeHost}:${chrome.port}.`);
 
   CDP({
     host: chrome.host,
     port: chrome.port,
   }, client => {
-    console.log('Created CDP.');
-
     const {Page, Network, Runtime} = client;
+    const pagesLeft = PAGES.slice();
+    const loadNextPage = () => {
+      if (pagesLeft.length === 0) {
+        console.log(`Finished visiting ${PAGES.length} pages with no errors.`);
+        terminate(0);
+      } else {
+        const page = pagesLeft.pop();
+        const url = `${server.url}${page}`;
+        console.log(`Navigating to ${page}.`);
+        Page.navigate({url});
+      }
+    };
     const terminate = exitCode => {
       client.close().then(() => {
         chrome.kill().then(() => {
@@ -90,32 +106,38 @@ Promise.all([runServer(), getChrome()]).then(([server, chrome]) => {
         terminate(1);
       });
       Page.loadEventFired(() => {
-        console.log('Page loaded, running aXe.');
         Runtime.evaluate({
           expression: AXE_JS + ';(' + runAxe.toString() + ')()',
           awaitPromise: true,
         }).then(details => {
-          let exitCode = 0;
+          let errorFound = false;
           if (details.result.type === 'string') {
             const violations = JSON.parse(details.result.value);
-            if (violations.length === 0) {
-              console.log('No aXe violations found. Hooray!');
-            } else {
+            if (violations.length > 0) {
               console.log(`Found ${violations.length} aXe violations. Alas.`);
               console.log(violations);
-              exitCode = 1;
+              errorFound = true;
             }
           } else {
             console.log('Unexpected result from CDP!');
             console.log(details.result);
-            exitCode = 1;
+            errorFound = true;
           }
-          terminate(exitCode);
+          // Note that this means we're terminating on the first error we
+          // find, rather than reporting the error and moving on to the
+          // next page. We're doing this because it's possible that the
+          // error is caused by a layout or include, which may result
+          // in the same errors being reported across multiple pages, so
+          // we'd rather avoid the potential spam and just exit early.
+          if (errorFound) {
+            terminate(1);
+          } else {
+            loadNextPage();
+          }
         });
       });
 
-      console.log(`Navigating to ${server.url}.`);
-      Page.navigate({url: server.url});
+      loadNextPage();
     });
   });
 });

--- a/config/run-axe.js
+++ b/config/run-axe.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const urlParse = require('url').parse;
 const chromeLauncher = require('chrome-launcher');

--- a/config/run-axe.js
+++ b/config/run-axe.js
@@ -71,7 +71,6 @@ Promise.all([runServer(), getChrome()]).then(([server, chrome]) => {
         process.exit(1);
       });
       Page.loadEventFired(() => {
-        // TODO: Ensure we're not just on a "network error" type page.
         console.log('Page loaded, running aXe.');
         Runtime.evaluate({
           expression: AXE_JS + ';(' + runAxe.toString() + ')()',

--- a/config/run-axe.js
+++ b/config/run-axe.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const chromeLauncher = require('chrome-launcher');
+const CDP = require('chrome-remote-interface');
+const runServer = require('./static-server');
+
+const AXE_JS = fs.readFileSync(__dirname + '/../node_modules/axe-core/axe.js');
+
+function launchChrome(headless=true) {
+  return chromeLauncher.launch({
+    chromeFlags: [
+      '--window-size=412,732',
+      '--disable-gpu',
+      headless ? '--headless' : ''
+    ]
+  });
+}
+
+// This function is only here so it can be easily .toString()'d
+// and run in the context of a web page by Chrome. It will not
+// be run in the node context.
+function runAxe() {
+  return new Promise((resolve, reject) => {
+    window.axe.run((err, results) => {
+      if (err) return reject(err);
+      resolve(JSON.stringify(results.violations));
+    });
+  });
+}
+
+Promise.all([runServer(), launchChrome()]).then(([server, chrome]) => {
+  const port = server.address().port;
+  console.log(`Chrome is debuggable on ${chrome.port}.`);
+  CDP({
+    port: chrome.port,
+  }, client => {
+    console.log('Created CDP.');
+
+    const {Page, Runtime} = client;
+
+    Promise.all([
+      Page.enable()
+    ]).then(() => {
+      Page.loadEventFired(() => {
+        // TODO: Ensure we're not just on a "network error" type page.
+        console.log('Page loaded, running aXe.');
+        Runtime.evaluate({
+          expression: AXE_JS + ';(' + runAxe.toString() + ')()',
+          awaitPromise: true,
+        }).then(details => {
+          let exitCode = 0;
+          if (details.result.type === 'string') {
+            const violations = JSON.parse(details.result.value);
+            if (violations.length === 0) {
+              console.log('No aXe violations found. Hooray!');
+            } else {
+              console.log(`Found ${violations.length} aXe violations. Alas.`);
+              console.log(violations);
+              exitCode = 1;
+            }
+          } else {
+            console.log('Unexpected result from CDP!');
+            console.log(details.result);
+            exitCode = 1;
+          }
+          client.close().then(() => {
+            chrome.kill();
+            server.close();
+            console.log(`Terminating with exit code ${exitCode}.`);
+            process.exit(exitCode);
+          });
+        });
+      });
+
+      const url = `http://localhost:${port}`;
+      console.log(`Navigating to ${url}.`);
+      Page.navigate({url: url});
+    });
+  });
+});

--- a/config/static-server.js
+++ b/config/static-server.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+
+const app = express();
+
+const SITE_PATH = path.normalize(`${__dirname}/../_site`);
+
+if (fs.existsSync(SITE_PATH)) {
+  app.use(express.static(SITE_PATH));
+} else {
+  console.log(`Please build the site before running me.`);
+  process.exit(1);
+}
+
+module.exports = () => {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(() => {
+      resolve(server);
+    });
+  });
+};

--- a/config/static-server.js
+++ b/config/static-server.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const express = require('express');
 
@@ -16,7 +17,14 @@ if (fs.existsSync(SITE_PATH)) {
 module.exports = () => {
   return new Promise((resolve, reject) => {
     const server = app.listen(() => {
-      resolve(server);
+      const hostname = os.hostname();
+      const port = server.address().port;
+      resolve({
+        hostname,
+        port,
+        url: `http://${hostname}:${port}`,
+        httpServer: server,
+      });
     });
   });
 };

--- a/config/static-server.js
+++ b/config/static-server.js
@@ -17,7 +17,7 @@ if (fs.existsSync(SITE_PATH)) {
 module.exports = () => {
   return new Promise((resolve, reject) => {
     const server = app.listen(() => {
-      const hostname = os.hostname();
+      const hostname = os.hostname().toLowerCase();
       const port = server.address().port;
       resolve({
         hostname,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postinstall": "bundle",
     "prestart": "gulp build",
     "start": "bundle exec jekyll serve --drafts --future",
-    "test": "npm run lint && npm run crawl && bundle exec rspec",
+    "test": "npm run axe && npm run lint && npm run crawl && bundle exec rspec",
+    "axe": "node config/run-axe.js",
     "crawl": "node config/crawl.js",
     "watch": "nswatch"
   },
@@ -64,8 +65,11 @@
   },
   "homepage": "https://github.com/18F/web-design-standards-docs#readme",
   "dependencies": {
+    "axe-core": "^2.3.1",
     "browserify": "^13.0.0",
     "chalk": "^1.1.3",
+    "chrome-launcher": "^0.3.1",
+    "chrome-remote-interface": "^0.24.1",
     "del": "^2.2.0",
     "express": "^4.15.3",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Fixes #326.

This runs [axe-core](https://github.com/dequelabs/axe-core) on a few pages of the standards during CI and `npm test` runs. In future PRs we can add support for running it on more pages.

A successful run looks something like this:

> ![2017-07-12_15-43-34](https://user-images.githubusercontent.com/124687/28136780-fc177cc0-6718-11e7-8803-750b651de81f.png)

It requires that Chrome/Chromium v59 or higher be installed on the host system. I decided on [headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome) because:

* It's maintained by the Google Chrome team, so it's likely to be very well-maintained going forward. Possibly even moreso than Phantom; I vaguely recall seeing a Tweet from Ariya Hidayat a while back saying that Phantom was going to be end-of-life'd since Chromium is headless is officially supported now, but I could be totally wrong on that.
* I haven't done any formal measurements, but headless Chrome seems _really_ fast compared to Phantom.
* In the vast majority of cases, it's just one less thing for developers to install--every developer I know has Chrome installed on their system, and our use of `chrome-launcher` ensures that it will be found, regardless of host OS.
* I noticed we have a (kind of old) WIP PR to add support for Google Lighthouse in #210, so this PR might make continuing work on that easier too,
* Chrome is a real browser, unlike PhantomJS, so it's likely that any errors can be reproduced and debugged using Chrome running in non-headless (headed?) mode.

To do:
- [x] Ensure this works on CircleCI.
- [x] Ensure we're running aXe on the actual front page and not e.g. a "network error" page.
- [x] Ensure that [`docker-uswds`](https://github.com/toolness/docker-uswds) can run this too.
- [x] Update README to indicate that developers should have Chrome/Chromium installed on their systems for tests to run properly.
- [x] Modify `crawl.js` to use `static-server.js` to prevent duplication of code.
