### PR TITLE
Change Homepage Title

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: landing
-title: Announcing version 1.1
+title: A design system for government digital services
 hero:
   callout: U.S. Web Design Standards
   content: The Standards are a design system that allows federal agencies to quickly prototype and deploy digital products using a baseline of design patterns.


### PR DESCRIPTION
The current title on the homepage was leftover from the 1.0 launch and being manually updated for new releases. Since we aren't currently announcing a milestone release this is a proposed text change for a more generic homepage title.