### PR TITLE
List 18F/django-uswds-forms in implementations.yml

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -6,6 +6,15 @@
   version: 0.12.0
   notes: "This package provides access to the Standards in [Django](https://www.djangoproject.com/) applications."
 
+- name: Django
+  url: http://django-uswds-forms.readthedocs.io/en/latest/
+  author:
+    name: 18F
+    url: https://github.com/18F
+  version: 0.0.3
+  notes: |
+    This package provides Django Forms integration with the Standards.
+
 - name: Drupal
   url: https://www.drupal.org/project/uswds
   author:


### PR DESCRIPTION
This adds [django-uswds-forms](http://django-uswds-forms.readthedocs.io/en/latest/) on the [implementations](https://standards.usa.gov/getting-started/implementations/) page.

django-uswds-forms is a package I wrote a few months ago that encapsulates a bunch of logic we added to CALC in order to make it possible to render [Django `Form` objects](https://docs.djangoproject.com/en/1.11/ref/forms/api/) with Standards-based widgets. This essentially means that developers don't have to write any custom HTML or CSS to get the USWDS user experience.

It's actually completely orthogonal to the other Django package we list, [django-designstandards](https://github.com/department-of-veterans-affairs/django-designstandards): all that package does is add the USWDS JS and CSS to a Django project's collection of static files, so that they can be referenced in templates. In contrast, django-uswds-forms does *not* include the USWDS static assets, opting instead to let clients decide whether they want to use django-designstandards or bring in the assets via other means (e.g. npm, which is what CALC does). So in that sense, the two Django packages are complementary and worth listing, though I'm not sure how best to explain the distinction between the two as I have here.

