### PR TITLE
Find duplicate "id" attributes when crawling site

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -7,6 +7,7 @@
   notes: "This package provides access to the Standards in [Django](https://www.djangoproject.com/) applications."
 
 - name: Django
+  id: django-uswds-forms
   url: http://django-uswds-forms.readthedocs.io/en/latest/
   author:
     name: 18F
@@ -80,6 +81,7 @@
   notes: "This is not a reusable WordPress theme, but an implementation of the Standards for [bbg.gov](https://www.bbg.gov/)."
 
 - name: WordPress
+  id: wordpress-benjamin
   url: https://github.com/kyle-jennings/Benjamin
   author:
     name: Kyle Jennings

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "axe-core": "^2.3.1",
     "browserify": "^13.0.0",
     "chalk": "^1.1.3",
+    "cheerio": "^1.0.0-rc.2",
     "chrome-launcher": "^0.3.1",
     "chrome-remote-interface": "^0.24.1",
     "del": "^2.2.0",

--- a/pages/getting-started/implementations.md
+++ b/pages/getting-started/implementations.md
@@ -44,7 +44,7 @@ If you have a new implementation to add to this list, please [open an issue] or 
     </tr>
   </thead>
 {% for impl in site.data.implementations %}
-  <tr id="{{ impl.name | slugify }}">
+  <tr id="{% if impl.id %}{{ impl.id }}{% else %}{{ impl.name | slugify }}{% endif %}">
     <th scope="row">
       <strong><a href="{{ impl.url }}">{{ impl.name }}</a></strong>
     </th>

--- a/pages/performance/glossary.md
+++ b/pages/performance/glossary.md
@@ -84,14 +84,14 @@ The following gives a brief overview of a handful of metrics. If you're looking 
 
 [The `load` event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onload) fires at the end of the document loading process. At this point, all of the objects in the document are in the DOM, and all the images, scripts, links, and sub-frames have finished loading.
 
-#### Pros
+<h4>Pros</h4>
 - Easy to calculate for most pages
 - Can be calculated in any environment, on almost any browser
 
-#### Cons
+<h4>Cons</h4>
 - It's not a valid metric for perceived user performance because the page may be fully rendered and active before the `load` event fires. For more information see: [Steve Souders, moving beyond window onload](https://www.stevesouders.com/blog/2013/05/13/moving-beyond-window-onload/).
 
-#### How to measure
+<h4>How to measure</h4>
 Onload can be measured in the browser with the [performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance), which is available in all browsers except Internet Explorer 9 or earlier and Safari:
 
 ```
@@ -132,14 +132,14 @@ Another, less accurate method that works in all browsers is to use the JavaScrip
 
 Speed index is a score for the visual completeness of the page — above the fold (what’s visible to the user) — over time. It uses video capture to calculate this score. Created by [WebPagetest], it's a score from 0 to infinity that maps approximately to milliseconds of time before the page is completely visible to the user. A lower score is better.
 
-#### Pros
+<h4>Pros</h4>
 - Accurately measures user’s perceived performance
 
-#### Cons
+<h4>Cons</h4>
 - Requires a live URL to test, or
 - Requires a [WebPagetest] instance or service
 
-#### How to measure
+<h4>How to measure</h4>
 
 ##### With [WebPagetest]
 
@@ -177,15 +177,15 @@ Custom metrics are millisecond or second timings of how long a specific feature 
 
 The typical example of a custom metric is Twitter using a "time to first tweet." In this case, Twitter measures the time in milliseconds for the first tweet to appear to the user.
 
-#### Pros
+<h4>Pros</h4>
 - Very closely related to the organization's goals for the site
 - Good at testing user perceived performance, such as speed index, but does not require a live URL or complex testing setup
 
-#### Cons
+<h4>Cons</h4>
 - Challenging to manage on a site where the object being timed changes often, such as a blog
 - Hard to manage on sites with many different page templates
 
-#### How to measure
+<h4>How to measure</h4>
 1. Pick an event to measure. The event will be more accurate if it includes an image.
 2. Include a performance mark right after the HTML code with the event.
 
@@ -211,20 +211,20 @@ The typical example of a custom metric is Twitter using a "time to first tweet."
 
 [First meaningful paint](https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint) is a browser-supplied metric that measures how long it takes for the most meaningful content to be fully rendered on the site. Measurement involves watching all layout events as the page loads, filtering by events for new objects above the page fold, and then accounting for web font loading. By using these heuristics, the metric is a relatively accurate measure of how long it takes for the most important content on the site to be fully rendered. This was confirmed by having first meaningful paint tested against speed index for a large number of sites. This metric is closely related to speed index, as both are accurate measurements of a user’s perceived performance.
 
-#### Pros
+<h4>Pros</h4>
 - Similar to speed index, it is a very accurate measurement of how the user perceives the performance of a site.
 - Does not require a complex testing setup or live URL
 
-#### Cons
+<h4>Cons</h4>
 - Only available in Google Chrome
 
-#### How to measure
+<h4>How to measure</h4>
 First meaningful paint can be measured in one of two ways:
 
-##### Lighthouse
+<h5>Lighthouse</h5>
 [Lighthouse], the Chrome plugin and command line testing tool, includes first meaningful paint as one of the metrics it tests. To test, run either the plugin on your site or the [CLI tool](https://developers.google.com/web/tools/lighthouse/#cli) with the appropriate options.
 
-##### Chrome web browser
+<h5>Chrome web browser</h5>
 You can measure first meaningful paint timing for any page in the [Chrome DevTools Timeline](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/timeline-tool).
 
 ### Time to interactive
@@ -237,22 +237,22 @@ This metric can be calculated through the browser timings API, [the `Performance
 
 Time to interactive can be nicely paired with speed index or first meaningful paint, as both test when the page is visually complete, while time to interactive tests when the page can be interacted with by the user. The purpose and the content of the site will determine which metric is more important, and may determine whether time to first interactive is even necessary to measure. For example, if the site is heavy on content (such as a blog), then first interactive may not be necessary because the user’s only "interaction" with the site is to read it.
 
-#### Pros
+<h4>Pros</h4>
 - For some sites, interaction may be more important than everything visually appearing, meaning this is a very important metric.
 - Relatively easy to test with [Lighthouse]
 
-#### Cons
+<h4>Cons</h4>
 - May not provide useful data for content-heavy sites without interactive elements
 - May not be possible to test in browsers other than Chrome
 
-#### How to measure
+<h4>How to measure</h4>
 Time to interactive can be measure in one of two ways:
 
-##### Lighthouse
+<h5>Lighthouse</h5>
 
 [Lighthouse], the Chrome plugin and command line testing tool, includes time to interactive as one of the metrics it tests. To test, run either the plugin on your site or the [CLI tool](https://developers.google.com/web/tools/lighthouse/#cli) with the appropriate options.
 
-##### Chrome web browser
+<h5>Chrome web browser</h5>
 
 Time to interactive can be found in statistics in the Chrome browser.
 
@@ -260,14 +260,14 @@ Time to interactive can be found in statistics in the Chrome browser.
 
 Input latency is the amount of time it takes for the app to respond to the users as they interact with it. It’s very different than the other metrics, as it doesn’t relate to the initial load and displaying of the page; it’s a metric that is constantly being tracked over time, as the user interacts with the site. Due to how input latency works, it’s often best served as a [RUM metric](#real-time-monitoring), as it’s more accurate to gather information as real users are interacting with the site. It’s also possible to test [synthetically](#synthetic-monitoring). For more information, see [Lighthouse's input latency documentation](https://developers.google.com/web/tools/lighthouse/audits/estimated-input-latency).
 
-#### Pros
+<h4>Pros</h4>
 - It's the only metric that tests how the site responds over time as the user interacts with it.
 
-#### Cons
+<h4>Cons</h4>
 - Harder to quantify with other metrics
 - Hard to measure accurately
 
-#### How to measure
+<h4>How to measure</h4>
 The only known way to test input latency right now is with [Lighthouse]. This tool is able to keep a watch on the browser thread to know when it’s free after a user clicks on or interacts with the site.
 
 ### Render start
@@ -276,14 +276,14 @@ Render start is the time from the [first byte](#first-byte) to when the browser 
 
 Render start measures how long it takes for blocking scripts, style sheets, and other processes to complete before the browser can start rendering the page. It will point to problems in the request pipeline, such as not deferring or placing scripts at the end of the document, or requiring too many blocking CSS resources. It’s generally less useful than more complete visual metrics, such as [speed index](#speed-index) and [first paint](#first-paint).
 
-#### Pros
+<h4>Pros</h4>
 - It's very accurate.
 
-#### Cons
+<h4>Cons</h4>
 - Requires complex testing setups such as [WebPagetest]
 - Isn't as thorough as speed index and meaningful first paint
 
-#### How to measure
+<h4>How to measure</h4>
 Render start can be measured along with speed index with [WebPagetest] or similar tools. For more information, see the [speed index](#speed-index) instructions.
 
 ### First paint
@@ -292,15 +292,15 @@ First paint is a browser-based metric supplied that indicates the amount of time
 
 The main reason to use first paint over the more accurate [render start](#render-start) is its ease of use in [realtime user monitoring](#real-time-monitoring), as it’s available in most browsers.
 
-#### Pros
+<h4>Pros</h4>
 - Can be accessed via realtime user monitoring
 - Very easy to test
 
-#### Cons
+<h4>Cons</h4>
 - Not accurate in some browsers
 - Sometimes not accurate at all
 
-#### How to measure
+<h4>How to measure</h4>
 
 First paint can be accessed via the [performance timing API] in supported browsers, such as recent versions of Chrome, Firefox, and Internet Explorer. In Internet Explorer it can be accessed via `performance.timing.msFirstPaint` ([more info from Microsoft](https://msdn.microsoft.com/en-us/library/ff974719(v=vs.85).aspx)). In Chrome it can be accessed via `window.chrome.loadTimes().firstPaintTime` ([more info from Chrome](https://gist.github.com/acdha/a1fd7e91f8cd5c1f6916)). It’s also available in most testing tools.
 
@@ -308,30 +308,30 @@ First paint can be accessed via the [performance timing API] in supported browse
 
 First byte is time from which the first request went out from the browser to the server, to when the first byte from the server comes back to the browser. It measures the time it takes the browser to respond, so it's sometimes called "backend time".
 
-#### Pros
+<h4>Pros</h4>
 - Good way to find problems with backend systems related to performance
 - Easy to test, and available in most testing tools
 
-#### Cons
+<h4>Cons</h4>
 - Doesn't tell the big picture, like speed index or meaningful first paint
 - Doesn't get into details of backend response, so might be better served by more backend-related tools rather than browsers
 
-#### How to measure
+<h4>How to measure</h4>
 First byte is available in the standardized Navigation Timing API for any browsers that support it. It’s under the `responseStart` event. It’s also available in most testing tools.
 
 ### Total page weight
 
 This metric, also called "total requests", is an accrual of all a site's resource weights, measured in kilobytes or megabytes, including the HTML of the page itself. It's useful for setting weight budgets on a site, which are easy to pass to developers and designers. It doesn't always tell the whole story of performance, as performance often depends on how a page loads those requests.
 
-#### Pros
+<h4>Pros</h4>
 - Easy understand at all points in the process, from design to development
 - Easy to test
 - Can be tested with [RUM](#real-time-monitoring)
 
-#### Cons
+<h4>Cons</h4>
 - Doesn't tell the whole story of site performance, as it also matters how the resources are loaded
 
-#### How to measure
+<h4>How to measure</h4>
 Total resource weight can be calculated with the [resource timing API](https://developer.mozilla.org/en-US/docs/Web/API/Resource_Timing_API/Using_the_Resource_Timing_API):
 
 ```js
@@ -349,14 +349,14 @@ The number of requests is the total number of requests that the page makes while
 
 Note: The number of requests matters much less if your site is being served over HTTP/2. For more information on HTTP/2 and it's implications on site speed, [see our guide](/performance/http2).
 
-#### Pros
+<h4>Pros</h4>
 - Very easy to test
 
-#### Cons
+<h4>Cons</h4>
 - Will become obsolete for any site served over HTTP/2
 - Doesn't account for resources being served over multiple domains, so doesn't always impact performance directly
 
-#### How to measure
+<h4>How to measure</h4>
 
 The number of requests can be obtained with the [resource timing API](https://developer.mozilla.org/en-US/docs/Web/API/Resource_Timing_API/Using_the_Resource_Timing_API):
 
@@ -370,15 +370,15 @@ The number of DOM nodes is a rough measure of the amount of HTML content on the 
 
 When relating DOM node count to performance, it’s usually more important to maintain a high upper limit rather than continually trying to reduce the count. This is because DOM nodes only become a problem for performance when there are a lot of them --- specifically, upwards of 1,500. Removing a small number of DOM nodes from your site if there are already fewer than 1,500 won't have a noticeable affect on performance. DOM node count also relates to input latency: If the browser has too many DOM nodes to manage, it will not be able to keep up with the user’s interactions as quickly.
 
-#### Pros
+<h4>Pros</h4>
 - Easy to test
 - Can be tested with [RUM](#real-time-monitoring)
 
-#### Cons
+<h4>Cons</h4>
 
 - Reducing the number of DOM nodes doesn’t usually have a large impact on performance.
 
-#### How to measure
+<h4>How to measure</h4>
 
 You can access the number of DOM nodes on any page via the DOM API in all browsers:
 

--- a/pages/performance/how.md
+++ b/pages/performance/how.md
@@ -234,19 +234,19 @@ In this section, we’ll discuss a few of the many ways to track web performance
 
 Tracking performance through a new, or existing, Continuous Integration (CI) service can often be the cheapest and most robust tracking method. Usually tracking on a CI is more geared to the developer team, but all team members can access the information on the CI and incorporate it into their workflow.
 
-##### What you’ll need:
+<h5>What you'll need:</h5>
 
 - A continuous integration server or service, which is able to run your site’s build at certain points during code changes. Some example free services include [CircleCI](https://circleci.com/) or [Travis CI](https://travis-ci.org/).
 - A build process that can run your website in a local, real or test environment, so that it can be visited at a localhost or staging URL
 - The ability to add new tools to be run during your continuous integration build
 
-##### Pros
+<h5>Pros</h5>
 
 - See speed changes at a very early part in the code release process, before it makes it to the live site
 - Can block code from going to production that would cause large speed slowdowns
 - Can run in multiple environments, like dev or staging
 
-##### Cons
+<h5>Cons</h5>
 
 - Harder to involve the full team in site performance tracking
 - Don’t know if simulated environment in build is close to what real users are experiencing
@@ -255,16 +255,16 @@ Tracking performance through a new, or existing, Continuous Integration (CI) ser
 
 Real-time user monitoring (RUM) is the only performance tracking method that allows you to see true performance measurements from users, getting your team to a closer understanding of how they experience the site. There’s plenty of information about RUM monitoring in the glossary. There are also costs and benefits to this solution.
 
-##### What you’ll need:
+<h5>What you'll need:</h5>
 
 - Ability to add a JS script to your site to track performance
 - A paid backend service provider or manual backend service to collect performance data. An example service is [SpeedCurve](https://speedcurve.com/).
 
-##### Pros
+<h5>Pros</h5>
 
 - The most accurate measurement of what users are experiencing
 
-##### Cons
+<h5>Cons</h5>
 
 - Not possible to measure important metrics, such as [Speed index](../glossary/#speed-index), meaningful first paint, [input latency](../glossary/#input-latency)
 - Requires many users to see useful data, more than 500 uniques per day
@@ -274,14 +274,14 @@ Real-time user monitoring (RUM) is the only performance tracking method that all
 
 A Content Management Solution (CMS) tracker should only be used if your site has a CMS, and your research has shown that the majority of performance issues relate to content being updated in the CMS. This solution will track and report on performance during the CMS content editing process.
 
-##### What you’ll need:
+<h5>What you'll need:</h5>
 
-##### Pros
+<h5>Pros</h5>
 
 - Can alert users that may not be as familiar with performance when they’re writing CMS content that has performance implications
 - Only reports performance when things in the system could change
 
-##### Cons
+<h5>Cons</h5>
 
 - Lack of tools in CMS performance tracking, so relatively hard to configure
 

--- a/pages/whats-new/research.md
+++ b/pages/whats-new/research.md
@@ -62,20 +62,20 @@ The best way to learn how well the Standards are working is to watch people usin
 #### Package 1 - Remote Usability Evaluation
 We will recruit users of your product -- usually no more than 20 -- and observe them using it via remote, online web conferencing tools. This approach is meant to highlight high level issues that your users are experiencing and provide guidance on future iterations of your product. Your team is encouraged to observe the sessions; our researchers will report back their findings.
 
-##### Outcomes
+<h5>Outcomes</h5>
 * Report with high level findings and recommendations for the partner agency
 
-##### Cost and Timeline
+<h5>Cost and Timeline</h5>
 * Cost: $65,000 to $80,000
 * Timeline: 4 to 5 weeks
 
 #### Package 2 - In-Person Usability Evaluation
 We will recruit users of your product -- usually no more than 20 -- and observe them using it in person at a location to be determined. This evaluation is meant to be an in-depth analysis of your product, exposing both general trends and specific issues that affect your users. Your team is encouraged to observe the sessions, on location and via remote conferencing tools, and our researchers will report back their findings.
 
-##### Outcomes
+<h5>Outcomes</h5>
 * Report with high level findings and recommendations for the partner agency
 
-##### Cost and Timeline
+<h5>Cost and Timeline</h5>
 * Cost: $80,000 to $95,000 (includes travel costs; additional recruitment and testing facility fees may apply)
 * Timeline: 5 to 6 Weeks
 
@@ -86,23 +86,23 @@ With the enrollment into the Data Analytics Platform (DAP) being part of the Pol
 #### Package 1 - DAP Integration
 We will work with digital services teams to put the basic code needed into place for passing their web analytics into the DAP platform. This is a lightweight service meant to assist teams that don’t have the necessary skills on hand to meet the policies requirements.
 
-##### Outcomes
+<h5>Outcomes</h5>
 * DAP code included on all required sites and pages
 * Integration into the DAP platform
 
-##### Cost and Timeline
+<h5>Cost and Timeline</h5>
 * Cost: $8,000 to $16,000
 * Timeline: 1 to 2 Weeks
 
 #### Package 2 - Basic Reporting and Dashboards
 In addition to the services described in the above package, an analyst will work with a digital service team to set up basic reporting and dashboards that give agencies greater insight into how people use its digital products. The information gathered can help inform outreach, business and technical strategy, and user research activities the digital service team might want perform.
 
-##### Outcomes
+<h5>Outcomes</h5>
 * DAP code included on all required sites and pages
 * Integration into the DAP platform
 * Requirements gathering of desired reports and dashboards
 * Report and dashboard set up
 
-##### Cost and Timeline
+<h5>Cost and Timeline</h5>
 * Cost: $24,000 to $31,000
 * Timeline: 3 to 4 Weeks


### PR DESCRIPTION
This is related to #357 but has more general use: we want to know if any of our pages have distinct elements with duplicate `id` attributes, because `id`s are supposed to be unique. Since `id`s are often used with JS and/or as link targets, it's particularly important that they be unique, or else the site may misbehave or take the user somewhere they don't want to go.

This PR adds support for finding duplicate `id` attributes when crawling our site:

![duplicate-ids](https://user-images.githubusercontent.com/124687/28392632-c547296e-6cb0-11e7-8bca-8fa7a1a6c80c.png)

To do
- [x] Fix the duplicate `id` errors so we don't break the build when merging this PR.
