### PR TITLE
Find duplicate "id" attributes when crawling site (Redcarpet subclassing approach)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,7 +61,7 @@ defaults:
       layout: post
 
 # Build settings
-markdown: redcarpet
+markdown: RedcarpetExtender
 redcarpet:
   extensions:
     - smart

--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -7,6 +7,7 @@
   notes: "This package provides access to the Standards in [Django](https://www.djangoproject.com/) applications."
 
 - name: Django
+  id: django-uswds-forms
   url: http://django-uswds-forms.readthedocs.io/en/latest/
   author:
     name: 18F
@@ -80,6 +81,7 @@
   notes: "This is not a reusable WordPress theme, but an implementation of the Standards for [bbg.gov](https://www.bbg.gov/)."
 
 - name: WordPress
+  id: wordpress-benjamin
   url: https://github.com/kyle-jennings/Benjamin
   author:
     name: Kyle Jennings

--- a/_plugins/redcarpet_extender.rb
+++ b/_plugins/redcarpet_extender.rb
@@ -1,0 +1,63 @@
+require 'redcarpet'
+
+class RedcarpetExtender < Redcarpet::Render::HTML
+  def initialize(opts = {})
+    super
+    @anchors = []
+  end
+
+  # This resolves duplicate header IDs the "numeric" way: if you have the
+  # same title twice then a number is appended to the anchor.
+  #
+  # Taken from https://github.com/vmg/redcarpet/issues/307.
+  def header(text, level)
+    number = 2
+
+    # https://stackoverflow.com/a/4308399
+    anchor = text.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+
+    while @anchors.include?(anchor)
+      if number > 2
+        anchor[-1] = number.to_s
+      else
+        anchor += "-#{number}"
+      end
+
+      number += 1
+    end
+
+    @anchors << anchor
+
+    %(<h#{level} id="#{anchor}">#{text}</h#{level}>)
+  end
+end
+
+class Jekyll::Converters::Markdown::RedcarpetExtender < Jekyll::Converters::Markdown::RedcarpetParser
+  # This is the exact same code as the superclass method, only
+  # we're substituting Redcarpet::Render::HTML for our custom
+  # subclass of it. Unfortunately, this means that as the
+  # original superclass implementation changes, we'll want to
+  # keep this trivial override up-to-date.
+  def class_with_proper_highlighter(highlighter)
+    Class.new(RedcarpetExtender) do
+      case highlighter
+      when "pygments"
+        include WithPygments
+      when "rouge"
+        Jekyll::External.require_with_graceful_fail(%w(
+          rouge rouge/plugins/redcarpet
+        ))
+
+        unless Gem::Version.new(Rouge.version) > Gem::Version.new("1.3.0")
+          abort "Please install Rouge 1.3.0 or greater and try running Jekyll again."
+        end
+
+        include Rouge::Plugins::Redcarpet
+        include CommonMethods
+        include WithRouge
+      else
+        include WithoutHighlighting
+      end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "axe-core": "^2.3.1",
     "browserify": "^13.0.0",
     "chalk": "^1.1.3",
+    "cheerio": "^1.0.0-rc.2",
     "chrome-launcher": "^0.3.1",
     "chrome-remote-interface": "^0.24.1",
     "del": "^2.2.0",

--- a/pages/getting-started/implementations.md
+++ b/pages/getting-started/implementations.md
@@ -44,7 +44,7 @@ If you have a new implementation to add to this list, please [open an issue] or 
     </tr>
   </thead>
 {% for impl in site.data.implementations %}
-  <tr id="{{ impl.name | slugify }}">
+  <tr id="{% if impl.id %}{{ impl.id }}{% else %}{{ impl.name | slugify }}{% endif %}">
     <th scope="row">
       <strong><a href="{{ impl.url }}">{{ impl.name }}</a></strong>
     </th>


### PR DESCRIPTION
This is just like #358 but takes an alternative approach to fixing duplicate ids caused by the kinds of header TOC issues described in https://github.com/18F/web-design-standards-docs/pull/358#issuecomment-316686935. Instead of using HTML in the markdown for duplicate headers, we subclass Redcarpet to provide our own custom id-collision algorithm.
