### PR TITLE
initial fractal link on Buttons component

### DIFF
--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -7,7 +7,7 @@ type: element
 title: Buttons
 category: UI components
 lead: Use buttons to signal actions.
-component_url: 'https://components.standards.usa.gov/components/detail/buttons.html'
+fractal_component_url: 'https://components.standards.usa.gov/components/detail/buttons.html'
 ---
 
 {% include code/preview.html component="buttons" %}

--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -7,6 +7,7 @@ type: element
 title: Buttons
 category: UI components
 lead: Use buttons to signal actions.
+component_url: 'https://components.standards.usa.gov/components/detail/buttons.html'
 ---
 
 {% include code/preview.html component="buttons" %}

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Site settings
 title:  U.S. Web Design Standards
 google_analytics_ua: UA-48605964-43
+components_url: 'https://components.standards.usa.gov'
 
 # this is for pages that don't have a permalink (primarily posts)
 permalink: /whats-new/updates/:year/:month/:day/:title/

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -16,13 +16,15 @@ layout: default
     <header>
       {% if page.category != null %}
         {% unless page.path contains 'overview' %}
-      <p class="site-subheading">{{ page.category }}</p>
+          <p class="site-subheading">{{ page.category }}</p>
         {% endunless %}
       {% endif %}
       <h1 id="{{ page.title | slugify }}">{{ page.title }}</h1>
-      <span class="components-library-link">
-        <a href="{{ page.component_url }}">View in Component Library</a>
-      </span>
+      {% if page.category == 'UI components' and page.component_url %}
+        <span class="components-library-link">
+          <a href="{{ page.component_url }}">View in Component Library</a>
+        </span>
+      {% endif %}
     </header>
 
     {% include lead.html text=page.lead %}

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -20,7 +20,7 @@ layout: default
         {% endunless %}
       {% endif %}
       <h1 id="{{ page.title | slugify }}">{{ page.title }}</h1>
-      {% if page.category == 'UI components' and page.component_url %}
+      {% if page.category == 'UI components' and page.fractal_component_url %}
         <span class="components-library-link">
           <a href="{{ page.component_url }}">View in Component Library</a>
         </span>

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -20,6 +20,9 @@ layout: default
         {% endunless %}
       {% endif %}
       <h1 id="{{ page.title | slugify }}">{{ page.title }}</h1>
+      <span class="components-library-link">
+        <a href="{{ page.component_url }}">View in Component Library</a>
+      </span>
     </header>
 
     {% include lead.html text=page.lead %}

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -366,6 +366,16 @@ body {
       display: inline-block;
       margin-top: 0;
     }
+
+    .components-library-link {
+      float: right;
+      padding-top: 20px;
+
+      a {
+        @include external-link(external-link, external-link-hover);
+        text-decoration: none;
+      }
+    }
   }
 
   section {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,11 @@
     "Roger Steve Ruiz <roger.ruiz@gsa.gov>",
     "Shawn Allen <shawn.allen@gsa.gov>",
     "Will Sullivan <william.sullivan@gsa.gov>",
-    "Yoz Grahame <jeremy.grahame@gsa.gov>"
+    "Yoz Grahame <jeremy.grahame@gsa.gov>",
+    "John Donmoyer <john.donmoyer@gsa.gov>",
+    "Ryan Thurwell <ryan.thurwell@gsa.gov>",
+    "Atul Varma <atul.varma@gsa.gov>"
+
   ],
   "license": "SEE LICENSE in LICENSE.md",
   "bugs": {

--- a/pages/ui-components/overview.html
+++ b/pages/ui-components/overview.html
@@ -6,4 +6,6 @@ category: UI components
 lead: Our system of UI components are designed to set a new bar for simplicity and consistency across government services, while providing you with plug-and-play design and code.
 ---
 
-For getting up and running with the Standards, head over to our <a href="{{ site.baseurl }}/getting-started/">Getting started</a> page for more information.
+<p>For getting up and running with the Standards, head over to our <a href="{{ site.baseurl }}/getting-started/">Getting started</a> page for more information.</p>
+
+<p>To browse the entire collection of U.S. Web Design Standards components, visit <a href="{{ site.fractal_url }}">components.standards.usa.gov</a>.</p>


### PR DESCRIPTION
![screen shot 2017-07-25 at 1 53 46 pm](https://user-images.githubusercontent.com/776987/28588614-b9129478-7140-11e7-9e4b-bd237fd5818c.png)

Adds a "view in component library" link to the pages on the docs site (just buttons for now)

@toolness is there anyway I could use the code you wrote for embedding fractal code samples to populate that URL field? 