### PR TITLE
Add links to graphic list on landing page

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -28,9 +28,23 @@ layout: default
     <div class="usa-grid usa-graphic_list-row">
       {% for list_item in page.graphic_list.list_item %}
         <div class="usa-width-one-fourth usa-media_block">
-          <img class="usa-media_block-img"  src="{{ list_item.image.src | relative_url }}" alt="{{ list_item.image.alt }}">
+          {% if list_item.href %}
+            <a href="{{ list_item.href | relative_url }}">
+              <img class="usa-media_block-img"  src="{{ list_item.image.src | relative_url }}" alt="{{ list_item.image.alt }}">
+            </a>
+          {% else %}
+            <img class="usa-media_block-img"  src="{{ list_item.image.src | relative_url }}" alt="{{ list_item.image.alt }}">
+          {% endif %}
           <div class="usa-media_block-body">
-            {% if list_item.topic %}<h3>{{ list_item.topic }}</h3>{% endif %}
+            {% if list_item.topic %}
+              {% if list_item.href %}
+                <a href="{{ list_item.href | relative_url }}">
+                  <h3>{{ list_item.topic }}</h3>
+                </a>
+              {% else %}
+                <h3>{{ list_item.topic }}</h3>
+              {% endif %}
+            {% endif %}
             {{ list_item.description | markdownify }}
           </div>
         </div>

--- a/pages/home.md
+++ b/pages/home.md
@@ -9,21 +9,25 @@ graphic_list:
   list_item:
     - topic: Getting Started
       description: Learn how to get started using the U.S. Web Design Standards for your project, regardless of your technical stack.
+      href: /getting-started/
       image:
         src: img/home/get-started.svg
         alt:
     - topic: UI Components
       description: Discover all the different components that the Standards provide as both design and development assets.
+      href: /components/
       image:
         src: img/home/ui-component.svg
         alt:
     - topic: What's New
       description: Keep up to date with the current news and product development updates for the U.S. Web Design Standards.
+      href: /whats-new/
       image:
         src: img/home/new.svg
         alt:
     - topic: Page Templates
       description: Explore the different page templates that have been created to jump start your product development.
+      href: /page-templates/
       image:
         src: img/home/page-templates.svg
         alt:


### PR DESCRIPTION
## Description

The landing page has a graphic list resembling the site navigation, which I went to click on, but noticed they're not links. I added conditional `<a>` tags to the template, trying to reuse the property name `href` from other YAML in this repo, but I noticed it adds some padding to the top, making a more significant change than I expected. As a result, this pull request is not quite merge-ready, but hopefully it's a helpful start! Didn't want to take too many liberties in adjusting the padding - only got my toes wet :)

## Additional information

<img width="1016" alt="screen shot 2017-07-26 at 11 22 14" src="https://user-images.githubusercontent.com/761444/28629385-479bcb9c-71f5-11e7-8904-0db95720a432.png">
^ An example of the vertical padding difference when compared with a graphic list item that doesn't have an `href`.