### PR TITLE
Disable form submission in HTML for sensitive forms

### DIFF
--- a/_includes/code/components/password-reset.html
+++ b/_includes/code/components/password-reset.html
@@ -33,6 +33,6 @@
         Show my typing</a>
     </p>
 
-    <input type="submit" value="Reset password">
+    <input type="submit" value="Reset password" disabled>
   </fieldset>
 </form>

--- a/_includes/code/components/sign-in-form.html
+++ b/_includes/code/components/sign-in-form.html
@@ -15,7 +15,7 @@
         Show password</a>
     </p>
 
-    <input type="submit" value="Sign in">
+    <input type="submit" value="Sign in" disabled>
 
     <p><a href="javascript:void(0);" title="Forgot username">
       Forgot username?</a></p>


### PR DESCRIPTION
This is an attempt to fix https://github.com/18F/web-design-standards/issues/2101.

As I understand it, the main rationale for disabling form submission, at least in this specific instance, is so that security scans on standards.usa.gov don't trigger false positives.  I wasn't forwarded the original email from the GSA IT folks though, so I'm not sure.

The thing is, #202 disables form submission for all components from the client-side, and I've verified that code is still working fine. However, if JS is disabled, it won't take effect. My guess is that the security scanner is trying to make sure that the site is secure even with JS disabled, so it's essentially evaluating the page that way.

I *think* one solution is to disable form submission at the HTML level, which is what this PR does. It seems to work when I disable JS on my browser.

The main downside with this approach, though, is that the `disabled` attribute on the submit buttons shows up in the "Code" accordion.  That's a bit annoying I guess, but it's not a deal-breaker--the alternative would be to have some sort of liquid tag that automatically inserts `disabled` attributes as needed before passing the HTML on to the syntax highlighter, but that's a lot of work.
