### PR TITLE
Release USWDS 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "politespace": "^0.1.4",
     "run-sequence": "^1.1.5",
     "simplecrawler": "^1.1.3",
-    "uswds": "1.3.0",
+    "uswds": "1.3.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }


### PR DESCRIPTION
This updates the version of uswds the `master` branch uses to 1.3.1, which was just released in https://github.com/18F/web-design-standards/pull/2119, so that we provide the download link for that version instead of the old one.

Fixes #385.