### PR TITLE
Update section on browser support.

### DIFF
--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -211,7 +211,12 @@ NOTE: If you plan on upgrading to newer versions of the Standards in the future,
 
 ## Notes on accessibility
 
-We’ve designed the Standards to support older and newer browsers through progressive enhancement, and they officially support Internet Explorer 9 and up, along with the latest versions of Chrome, Firefox, and Safari. Internet Explorer 8 and below generally see very low usage, and most agency websites should be able to safely begin support at Internet Explorer 9.
+- Originally the Standards were desiged to support Internet Explorer 9 and up
+- Now we're going to support any browser above 2% usage as defined on analytics.gov
+- This currently means we support only Internet Explorer 11 and up.
+- There will be no breaking changes in older browsers until a major release, ie 2.0.
+
+We’ve designed the Standards to support older and newer browsers through progressive enhancement. The Standards will officially support any browser **above 2% usage** as defined on [analytics.usa.gov](https://analytics.usa.gov/). This currently means the Standards supports the newest versions of Chrome, Firefox, Safari and Internet Explorer 11 and up. Due to the Standards originally browser support, the Standards will support Internet Explorer 9 and up until the next major release, `2.0`.
 
 The Standards also meet the [WCAG 2.0 AA accessibility guidelines](https://www.w3.org/TR/WCAG20/) and are compliant with [Section 508 of the Rehabilitation Act](http://www.section508.gov/). We’re happy to answer questions about accessibility — email us for more information.
 

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -209,14 +209,11 @@ NOTE: If you plan on upgrading to newer versions of the Standards in the future,
 * **Fonts** are located in: `src/fonts`.
 * **Images** and icons are located in: `src/img`.
 
-## Notes on accessibility
-
-- Originally the Standards were desiged to support Internet Explorer 9 and up
-- Now we're going to support any browser above 2% usage as defined on analytics.gov
-- This currently means we support only Internet Explorer 11 and up.
-- There will be no breaking changes in older browsers until a major release, ie 2.0.
+## Browser support
 
 We’ve designed the Standards to support older and newer browsers through progressive enhancement. The Standards will officially support any browser **above 2% usage** as defined on [analytics.usa.gov](https://analytics.usa.gov/). This currently means the Standards supports the newest versions of Chrome, Firefox, Safari and Internet Explorer 11 and up. Due to the Standards originally browser support, the Standards will support Internet Explorer 9 and up until the next major release, `2.0`.
+
+## Accessibility
 
 The Standards also meet the [WCAG 2.0 AA accessibility guidelines](https://www.w3.org/TR/WCAG20/) and are compliant with [Section 508 of the Rehabilitation Act](http://www.section508.gov/). We’re happy to answer questions about accessibility — email us for more information.
 

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -211,7 +211,7 @@ NOTE: If you plan on upgrading to newer versions of the Standards in the future,
 
 ## Browser support
 
-We’ve designed the Standards to support older and newer browsers through progressive enhancement. The Standards will officially support any browser **above 2% usage** as defined on [analytics.usa.gov](https://analytics.usa.gov/). This currently means the Standards supports the newest versions of Chrome, Firefox, Safari and Internet Explorer 11 and up. Due to the Standards originally browser support, the Standards will support Internet Explorer 9 and up until the next major release, `2.0`.
+We’ve designed the Standards to support older and newer browsers through progressive enhancement. The Standards will officially support any browser **above 2% usage** as defined on [analytics.usa.gov](https://analytics.usa.gov/). This currently means the Standards supports the newest versions of Chrome, Firefox, Safari and Internet Explorer 11 and up. Due to the Standards originally browser support, the Standards will continue to support Internet Explorer 9 and up until the next major release, `2.0`.
 
 ## Accessibility
 


### PR DESCRIPTION
This states / should state that the standards should support IE9 and up until a major release, and then will only support browsers above 2% usage on analytics.gov.

This could potentially be worded in a way where it would not need to be updated in the future, such as after a major release or after browser support changes on analytics.gov. If that's better, we can rewrite it as such.

Fixes https://github.com/18F/web-design-standards/issues/2071
