### PR TITLE
Updating the uswds-jekyll theme to 1.3.1

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -29,7 +29,7 @@
   author:
     name: 18F
     url: https://github.com/18F
-  version: 1.1.1
+  version: 1.3.1
   notes: "A [Jekyll](https://jekyllrb.com/) theme for the Standards."
 
 - name: npm and node-sass


### PR DESCRIPTION
Updating version in the docs for the uswds-jekyll theme to 1.3.1
More info here: https://github.com/18F/uswds-jekyll/releases/tag/v1.3.1