### PR TITLE
Update the lead on the sidenav docs

### DIFF
--- a/_components/sidenav.md
+++ b/_components/sidenav.md
@@ -6,7 +6,7 @@ layout: styleguide
 type: component
 title: Side navigation
 category: UI components
-lead: "Hierarchical, vertical navigation to place at the side of a page. Note: We're currently developing horizontal navigation and headers for the top of a page."
+lead: "Hierarchical, vertical navigation to place at the side of a page."
 ---
 
 {% include code/preview.html component="sidenav" %}


### PR DESCRIPTION
fixes #389 

removes reference to headers being under development as they have been released.