### PR TITLE
Fix broken links

### DIFF
--- a/_components/buttons.md
+++ b/_components/buttons.md
@@ -7,7 +7,7 @@ type: element
 title: Buttons
 category: UI components
 lead: Use buttons to signal actions.
-fractal_component_url: 'https://components.standards.usa.gov/components/detail/buttons.html'
+component_url: 'https://components.standards.usa.gov/components/detail/buttons.html'
 ---
 
 {% include code/preview.html component="buttons" %}

--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -20,7 +20,7 @@ layout: default
         {% endunless %}
       {% endif %}
       <h1 id="{{ page.title | slugify }}">{{ page.title }}</h1>
-      {% if page.category == 'UI components' and page.fractal_component_url %}
+      {% if page.category == 'UI components' and page.component_url %}
         <span class="components-library-link">
           <a href="{{ page.component_url }}">View in Component Library</a>
         </span>

--- a/pages/ui-components/overview.html
+++ b/pages/ui-components/overview.html
@@ -8,4 +8,4 @@ lead: Our system of UI components are designed to set a new bar for simplicity a
 
 <p>For getting up and running with the Standards, head over to our <a href="{{ site.baseurl }}/getting-started/">Getting started</a> page for more information.</p>
 
-<p>To browse the entire collection of U.S. Web Design Standards components, visit <a href="{{ site.fractal_url }}">components.standards.usa.gov</a>.</p>
+<p>To browse the entire collection of U.S. Web Design Standards components, visit <a href="{{ site.components_url }}">components.standards.usa.gov</a>.</p>


### PR DESCRIPTION
Fixes #411, #412.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-components-url)

**Note**: I don't know why we only have "View in the component library" link for only buttons and not the other components. It should be consistent.