### PR TITLE
Fix media block

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,7 +4,7 @@
   <head>
     {% include head.html %}
   </head>
-  <body class="page-{{ page.title | slugify }} layout-{{ page.layout }}">
+  <body class="page-{{ page.title | slugify }} layout-{{ page.layout }} {% if page.class %}page-{{ page.class | slugify }}{% endif %}">
     {{ content }}
     {% include scripts.html %}
   </body>

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -26,6 +26,7 @@ body {
     background-image: url('#{$site-image-path}/home/wds-home-new-2x.png');
     padding-bottom: 7.2rem;
     padding-top: 3.5rem;
+    -webkit-font-smoothing: antialiased;
   }
 
   .usa-hero-callout .usa-button {
@@ -474,8 +475,11 @@ a.cta {
 // Footer --------------- //
 
 footer.site {
-
   clear: both;
+
+  .usa-button {
+    font-weight: $font-bold;
+  }
 
   .logo-links {
     margin-bottom: 3rem;

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -19,6 +19,7 @@ body {
 .page-home {
   .usa-graphic_list .usa-media_block-img {
     max-width: 7rem;
+    margin-right: 2rem;
   }
 
   .usa-hero {
@@ -59,13 +60,15 @@ body {
   }
 
   .usa-media_block-img {
-    float: none;
     margin-bottom: 1rem;
+
+    @include media($large-screen) {
+      float: none;
+    }
   }
 
   .usa-section-dark p {
     margin-top: 0.8rem;
-    font-weight: $font-light;
   }
 
   // Override for 4x1 media grid when it collapses to 2x2

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -16,61 +16,63 @@ body {
   background-color: $color-primary-alt-lightest;
 }
 
-.usa-graphic_list .usa-media_block-img {
-  max-width: 7rem;
-}
-
-.usa-hero {
-  background-image: url('#{$site-image-path}/home/wds-home-new-2x.png');
-  padding-bottom: 7.2rem;
-  padding-top: 3.5rem;
-}
-
-.usa-hero-callout .usa-button {
-  margin-top: 2em;
-}
-
-.usa-hero-callout {
-  border-radius: 0.3rem;
-  max-width: 46rem;
-  padding: 3.6rem 3rem;
-
-  & > *:first-child {
-    margin-bottom: 0;
-  }
-}
-
-.usa-hero-callout-alt {
-  font-size: 2.7rem;
-}
-
-.usa-media_block-body {
-  & > *:first-child {
-    font-size: $media-block-header-font-size;
-    margin-top: 0;
-    margin-bottom: 0;
+.page-home {
+  .usa-graphic_list .usa-media_block-img {
+    max-width: 7rem;
   }
 
-  & > p {
-    margin: 0.5rem 0;
-    font-size: $media-block-body-font-size;
+  .usa-hero {
+    background-image: url('#{$site-image-path}/home/wds-home-new-2x.png');
+    padding-bottom: 7.2rem;
+    padding-top: 3.5rem;
   }
-}
 
-.usa-media_block-img {
-  float: none;
-  margin-bottom: 1rem;
-}
+  .usa-hero-callout .usa-button {
+    margin-top: 2em;
+  }
 
-.usa-section-dark p {
-  margin-top: 0.8rem;
-  font-weight: $font-light;
-}
+  .usa-hero-callout {
+    border-radius: 0.3rem;
+    max-width: 46rem;
+    padding: 3.6rem 3rem;
 
-// Override for 4x1 media grid when it collapses to 2x2
-@media screen and (max-width: $large-screen) and (min-width: $medium-screen) {
-  .usa-graphic_list .usa-graphic_list-row .usa-media_block:nth-child(-n+2) {
-    margin-bottom: 6rem;
+    & > *:first-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .usa-hero-callout-alt {
+    font-size: 2.7rem;
+  }
+
+  .usa-media_block-body {
+    & > *:first-child {
+      font-size: $media-block-header-font-size;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    & > p {
+      margin: 0.5rem 0;
+      font-size: $media-block-body-font-size;
+    }
+  }
+
+  .usa-media_block-img {
+    float: none;
+    margin-bottom: 1rem;
+  }
+
+  .usa-section-dark p {
+    margin-top: 0.8rem;
+    font-weight: $font-light;
+  }
+
+  // Override for 4x1 media grid when it collapses to 2x2
+  @media screen and (max-width: $large-screen) and (min-width: $medium-screen) {
+    .usa-graphic_list .usa-graphic_list-row .usa-media_block:nth-child(-n+2) {
+      margin-bottom: 6rem;
+    }
   }
 }
 
@@ -113,7 +115,6 @@ body {
 }
 
 .site-header {
-
   background-color: $color-primary-darkest;
 
   @include media($nav-width) {

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -26,7 +26,6 @@ body {
     background-image: url('#{$site-image-path}/home/wds-home-new-2x.png');
     padding-bottom: 7.2rem;
     padding-top: 3.5rem;
-    -webkit-font-smoothing: antialiased;
   }
 
   .usa-hero-callout .usa-button {

--- a/pages/home.md
+++ b/pages/home.md
@@ -2,6 +2,7 @@
 permalink: /
 layout: landing
 title: A design system for government digital services
+class: home
 hero:
   callout: U.S. Web Design Standards
   content: The Standards are a design system that allows federal agencies to quickly prototype and deploy digital products using a baseline of design patterns.


### PR DESCRIPTION
The media block code was applied to the whole site and not scoped to the intended homepage graphic list. This fixes that. Related to: https://github.com/18F/web-design-standards/issues/2141.

Also, fixes https://github.com/18F/web-design-standards/issues/2176.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-media_block)

- Removes antialiasing font smoothing from the homepage hero.
- Adjusts the media block styling so they're side-by-side. 
- Adds the ability to add a `class: class-name` into page frontmatter to add a class to the body, which will have a `page-*` appended to it.