### PR TITLE
Fix site typography bugs

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -332,16 +332,14 @@ body {
 // Main Content --------- //
 
 .main-content {
-  @include position(absolute, 4rem 0 0 null);
+  @include position(absolute, null 0 0 null);
   display: inline-block; // starting: not scrolled
   margin-top: 4rem; // starting: not scrolled
   position: relative;
   width: 100%;
-  top: 6.3rem; // height of disclaimer + navbar on mobile
 
   @include media($nav-width) {
     width: calc(100% - #{$width-nav-sidebar});
-    top: 0;
   }
 
   .lt-ie9 & {
@@ -363,7 +361,6 @@ body {
 
   header {
     > h1 {
-      display: inline-block;
       margin-top: 0;
     }
 
@@ -379,10 +376,6 @@ body {
   }
 
   section {
-    > h2 {
-      display: inline-block;
-    }
-
     > .tooltip {
       margin-top: 56px;
     }


### PR DESCRIPTION
- Removes extra spacing on mobile (Fixes #311)
- Removes inline-block display setting from h2's so margins collapse

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-site-typography)

### TODO:
Check whether or not we want/need the additional custom spacing on h2's and revisit how they should be applied.