### PR TITLE
Fix sidenav anchor links in releases

### DIFF
--- a/_includes/nav/link-item.html
+++ b/_includes/nav/link-item.html
@@ -1,7 +1,7 @@
 {% assign _href_key = include.href_key | default: 'href' %}
 {% if _href_key.size == 2 %}
   {% assign _key = _href_key[1] %}
-  {% assign _slug = link[_key] | slugify %}
+  {% assign _slug = link[_key] | replace: '.', '' | slugify %}
   {% assign _href = _href_key[0] | replace: '%', _slug %}
 {% else %}
   {% assign _href = link[_href_key] %}


### PR DESCRIPTION
This fixes the issue with anchor generation in the release notes, but I'm not sure it doesn't break something somewhere else. I don't now how this key replace is used in other sections.

A better solution might be to change how the `h2`s on this page generate their anchors, but idk how to do this on a case-by-case basis. It looks like Redcarpet is creating anchor slugs for heds by removing `.`s whereas `slugify` converts them to `-`s.

- - -

Note: Run `npm test` failed to run.
```
npm ERR! uswds-docs@1.3.0 axe: `node config/run-axe.js`
npm ERR! Exit status 1
``

Dunno what that means.