### PR TITLE
Add "The Standards" WordPress theme

### DIFF
--- a/_data/implementations.yml
+++ b/_data/implementations.yml
@@ -99,3 +99,12 @@
     url: https://github.com/kyle-jennings
   version: 1.1.0
   notes: "A WordPress theme built with Automattic's _s, 18F's U.S. Web Design Standards, and the needs of the people. For additional components and shortcodes, check out the [Franklin](https://github.com/kyle-jennings/Franklin) plugin."
+
+- name: WordPress
+  id: the-standards
+  url: https://github.com/LavertyCreative/The-Standards
+  author:
+    name: Kyle Laverty
+    url: https://github.com/lavekyl
+  version: 
+  notes: "The Standards is a WordPress theme that is based on the U.S. Web Design Standards."


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/add-wp-theme/getting-started/implementations/)

Resolves https://github.com/18F/web-design-standards-docs/issues/464.