### PR TITLE
Update homepage hero copy

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -22,6 +22,10 @@ body {
     background-image: url('#{$site-image-path}/home/wds-home-new-2x.png');
     padding-bottom: 7.2rem;
     padding-top: 3.5rem;
+
+    @include media($large-screen) {
+      padding-bottom: 10.6rem;
+    }
   }
 
   .usa-hero-callout .usa-button {
@@ -31,9 +35,10 @@ body {
   .usa-hero-callout {
     border-radius: 0.3rem;
     max-width: 46rem;
-    padding: 3.6rem 3rem;
+    padding: 3.2rem;
 
-    & > *:first-child {
+    & > :first-child,
+    & > :last-child {
       margin-bottom: 0;
     }
   }

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -21,7 +21,7 @@ body {
   .usa-hero {
     background-image: url('#{$site-image-path}/home/wds-home-new-2x.png');
     padding-bottom: 7.2rem;
-    padding-top: 3.5rem;
+    padding-top: 3.2rem;
 
     @include media($large-screen) {
       padding-bottom: 10.6rem;

--- a/pages/home.md
+++ b/pages/home.md
@@ -5,7 +5,7 @@ title: A design system for government digital services
 class: home
 hero:
   callout: A design system for the federal government
-  content: The Standards provides research-backed design patterns for building accessible, responsive, and consistent digital products for the federal government.
+  content: The Standards provide research-backed design patterns for building accessible, responsive, and consistent digital products for the federal government.
 graphic_list:
   list_item:
     - topic: Getting started

--- a/pages/home.md
+++ b/pages/home.md
@@ -4,8 +4,8 @@ layout: landing
 title: A design system for government digital services
 class: home
 hero:
-  callout: U.S. Web Design Standards
-  content: The Standards are a design system that allows federal agencies to quickly prototype and deploy digital products using a baseline of design patterns.
+  callout: A design system for the federal government
+  content: The Standards provides research-backed design patterns for building accessible, responsive, and consistent digital products for the federal government.
 graphic_list:
   list_item:
     - topic: Getting started


### PR DESCRIPTION
Updates the homepage hero copy to more accurately reflect the product vision. Also, adjusts hero spacing to match Sketch designs.
 
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/update-hero-copy)

Resolves #467.
  