### PR TITLE
Fix meta tag bugs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 # Site settings
 title:  U.S. Web Design Standards
+description: The Standards provide research-backed design patterns for building accessible, responsive, and consistent digital products for the federal government.
 google_analytics_ua: UA-48605964-43
 components_url: 'https://components.standards.usa.gov'
 

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,5 +1,7 @@
 {% assign title = site.title %}
-{% if page.title and page.title != title -%}
+{% if page.class == "home" -%}
+  {% assign title = page.title %}
+{% else %}
   {% assign title = page.title | append: ' | ' | append: title %}
 {% endif %}
 <title>{{ title }}</title>

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -6,8 +6,11 @@
 {% endif %}
 <title>{{ title }}</title>
 <meta property="og:title" content="{{ title | xml_escape }}">
+{% for post in site.posts %}
+  {% assign desc = page.excerpt %}
+{% endfor %}
 {% assign desc = page.description
-  | default: page.excerpt
+  | default: page.lead
   | default: site.description
   | strip_html
   | strip

--- a/pages/home.md
+++ b/pages/home.md
@@ -1,7 +1,7 @@
 ---
 permalink: /
 layout: landing
-title: A design system for government digital services
+title: "U.S. Web Design Standards: A design system for the federal government"
 class: home
 hero:
   callout: U.S. Web Design Standards


### PR DESCRIPTION
- Improves homepage meta title
- Adds missing meta description on homepage
- Adds site-wide description in config file
- Fixes #473 issue where the entire page content was being shown in the meta description on component pages by ensuring `page.excerpt` is only used on posts; now component pages use the `lead` text.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-meta-tag-issues)
  
  
  