### PR TITLE
Fix broken links to 18F's Front End Guide in "For developers > CSS" section

### DIFF
--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -128,17 +128,17 @@ You can also email us directly at [uswebdesignstandards@gsa.gov](mailto:uswebdes
 
 * The CSS foundation of this site is built with the **[Sass](https://sass-lang.com)** preprocessor language.
 * Uses **[Bourbon](http://bourbon.io/)** for its simple and lightweight Sass mixin library, and the **[Neat](http://neat.bourbon.io/)** library for the grid framework. Bourbon and Neat are open-source products from **[thoughtbot](https://thoughtbot.com/)**.
-* The CSS organization and naming conventions follow **[18F’s CSS Coding Styleguide](https://pages.18f.gov/frontend/css-coding-styleguide/)**.
+* The CSS organization and naming conventions follow **[18F’s CSS Coding Styleguide](https://frontend.18f.gov/css/)**.
 * CSS selectors are **prefixed** with `usa` (For example: `.usa-button`). This identifier helps the design system avoid conflicts with other styles on a site which are not part of the U.S. Web Design Standards.
-* Uses a **[modified BEM](https://pages.18f.gov/frontend/css-coding-styleguide/naming/)** approach created by 18F for naming CSS selectors. Objects in CSS are separated by single dashes. Multi-word objects are separated by an underscore (For example: `.usa-button-cool_feature-active`).
+* Uses a **[modified BEM](https://frontend.18f.gov/css/naming/)** approach created by 18F for naming CSS selectors. Objects in CSS are separated by single dashes. Multi-word objects are separated by an underscore (For example: `.usa-button-cool_feature-active`).
 * Uses **modular CSS** for scalable, modular, and flexible code.
 * Uses **nesting** when appropriate. Nest minimally with up to two levels of nesting.
 * Hard-coded magic numbers are avoided and, if necessary, defined in the `core/variables` scss file.
 * Media queries are built **mobile first**.
 * **Spacing units** are as much as possible defined as rem or em units so they scale appropriately with text size. Pixels can be used for detail work and should not exceed 5px (For example: 3px borders).
 
-**For more information, visit:
-[https://pages.18f.gov/frontend/css-coding-styleguide/](https://pages.18f.gov/frontend/css-coding-styleguide/)**
+**For more information, visit:**
+[18F’s CSS Coding Styleguide](https://frontend.18f.gov/css/)
 
 ## JS customization
 

--- a/pages/getting-started/developers.md
+++ b/pages/getting-started/developers.md
@@ -128,7 +128,7 @@ You can also email us directly at [uswebdesignstandards@gsa.gov](mailto:uswebdes
 
 * The CSS foundation of this site is built with the **[Sass](https://sass-lang.com)** preprocessor language.
 * Uses **[Bourbon](http://bourbon.io/)** for its simple and lightweight Sass mixin library, and the **[Neat](http://neat.bourbon.io/)** library for the grid framework. Bourbon and Neat are open-source products from **[thoughtbot](https://thoughtbot.com/)**.
-* The CSS organization and naming conventions follow **[18F’s CSS Coding Styleguide](https://frontend.18f.gov/css/)**.
+* The CSS organization and naming conventions follow **[18F’s CSS Front End Guide](https://frontend.18f.gov/css/)**.
 * CSS selectors are **prefixed** with `usa` (For example: `.usa-button`). This identifier helps the design system avoid conflicts with other styles on a site which are not part of the U.S. Web Design Standards.
 * Uses a **[modified BEM](https://frontend.18f.gov/css/naming/)** approach created by 18F for naming CSS selectors. Objects in CSS are separated by single dashes. Multi-word objects are separated by an underscore (For example: `.usa-button-cool_feature-active`).
 * Uses **modular CSS** for scalable, modular, and flexible code.
@@ -138,7 +138,7 @@ You can also email us directly at [uswebdesignstandards@gsa.gov](mailto:uswebdes
 * **Spacing units** are as much as possible defined as rem or em units so they scale appropriately with text size. Pixels can be used for detail work and should not exceed 5px (For example: 3px borders).
 
 **For more information, visit:**
-[18F’s CSS Coding Styleguide](https://frontend.18f.gov/css/)
+[18F’s CSS Front End Guide](https://frontend.18f.gov/css/)
 
 ## JS customization
 


### PR DESCRIPTION
[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/fix-broken-links)

Fixes: #460.