### PR TITLE
Add release file

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,2 @@
+# Update the docs repo with a new USWDS release
+Follow the [instructions in the main Standards repo](https://github.com/18F/web-design-standards/blob/develop/RELEASE.md#update-the-docs-repo-with-the-new-version-number-on-a-new-branch).


### PR DESCRIPTION
Adds release file which links to docs release section in the main `web-design-standards` repo.

Fixes #386, closes https://github.com/18F/web-design-standards/issues/2124.
  