### PR TITLE
Update product roadmap with 2018 roadmap

### DIFF
--- a/_data/milestones.yml
+++ b/_data/milestones.yml
@@ -1,132 +1,33 @@
-- title: Milestone 1 - Make the best thing the easiest thing.
-  id: milestone-1
+- title: 2018 Product roadmap
+  id: 2018-roadmap
   tasks:
-    - title: A public, up-to-date product road map.
-      status: Done
-      url: https://github.com/18F/web-design-standards/milestone/18
-    - title: A public maintenance plan.
-      status: Done
-      url: https://github.com/18F/web-design-standards/milestone/19
-    - title: A bare-bones HTML starter page, with CSS and JS pre-linked and necessary tags and classes.
-      status: In Progress
-      url: https://github.com/18F/web-design-standards/milestone/15
-    - title: Defined processes for active and public implementer support.
-      status: Done
-      url:
-    - title: Contribution guidelines for both designers and developers.
-      status: Done
-      url: https://github.com/18F/web-design-standards/blob/develop/CONTRIBUTING.md
-    - title: Form patterns that include recommendations for just-in-time instructions.
-      status: Done
-      url:
-    - title: UI components are comprised of clean, semantic code.
-      status: Done
-      url: https://github.com/18F/web-design-standards/milestone/13
-    - title: Simple "Getting Started" process and instructions.
-      status: Done
-      url: https://github.com/18F/web-design-standards/milestone/16
-    - title: A core set of common, usable web components.
-      status: Done
-      url: https://github.com/18F/web-design-standards/milestone/14
-    - title: Ready to go HTML templates (and related design stencils) for common types of government site pages.
-      status: Done
-      url: https://github.com/18F/web-design-standards/milestone/17
-
-- title: Milestone 2 - Design for flexibility. Reuse, reuse, reuse.
-  id: milestone-2
-  tasks:
-    - title: Form templates structured in short chunks.
-      status: Done
-      url:
-    - title: The ability to quickly copy and paste code from the website.
-      status: Done
-      url:
-    - title: Form patterns that allow for easy recovery of mistakes.
-      status: Done
-      url:
-    - title: Easy ways to customize the Standards to fit an agency’s brand and needs.
-      status: Done
-      url:
-    - title: Design stencils and assets.
-      status: Done
-      url: https://standards.usa.gov/download/
-    - title: Interaction patterns for save-as-you-go functionality
-      status: In Progress
-      url:
-    - title: A fork-able starter project representing a simple, static site with a few common pages.
-      status: Done
-      url:
-    - title: Build out the documentation and increase the ease of the process for Windows users to start up.
-      status: Done
-      url: https://github.com/18F/web-design-standards/issues/1533
-    - title: Final clean up and launch 1.0
-      status: Done
-      url: https://github.com/18F/web-design-standards/labels/%5BRelease%5D%201.0
-
-- title: Milestone 3 - Showcase benefits for agencies and users.
-  id: milestone-3
-  tasks:
-    - title: Highlight and track sites using the WDS more proactively, collect and link to them on the main site to show agencies what is possible.
-      status: In Progress
-      url: https://github.com/18F/web-design-standards/issues/1579
-    - title: Create and publicize a public slack channel for support, questions and sharing best practices.
-      status: Done
-      url: https://chat.18f.gov
-    - title: Start a series of Case Study and Best Practice blog posts sharing the work that agencies have done using the Web Design Standards and what they’ve learned.
-      status: Done
-      url: https://18f.gsa.gov/tags/web-design-standards/
-    - title: Produce more video tutorials and webinars for the community to learn how to more easily use the WDS.
-      status: In Progress
-      url:
-    - title: Produce DigitalGov webinars more frequently and find more speaking engagements to share the work and code.
-      status: In Progress
-      url: https://attendee.gotowebinar.com/register/6016615967957411842
-    - title: In an upcoming WDS site update, create a more visible location for all learning materials to showcase and help folks out.
-      status: In Progress
-      url:
-    - title: Build a tighter API integration with the Digital Analytics Program to track usage of the WDS to help guide our decision making, along with continued user interviews and research.
-      status: In Progress
-      url: https://github.com/18F/web-design-standards/issues/1635
-    - title: Continue listening tours to meet with more than a half dozen agencies per quarter to learn more about their experience, needs, and collect feedback on the Web Design Standards.
-      status: In Progress
-      url:
-
-- title: Milestone 4 - Advanced Components & Speed, Speed, Speed.
-  id: milestone-4
-  tasks:
-    - title: Perform a Web Performance review and update to components to make sure they’re optimized to load as fast as possible.
-      status: In Progress
-      url:
-    - title: Launch the Yeoman generator to quickly build out sites with the WDS base design.
-      status: In Progress
-      url: https://github.com/18F/web-design-standards/issues/1542
-    - title: Create a series of open source boilerplate language to include in government contracts to make it easier for Contracting Officers and Program Managers to define and request the use of the WDS in government contracts.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for wayfinding components, such as progress indicators.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for maps.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for data visualizations.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for standarized iconography.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for complex form structures.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for multi-lingual support for website chrome.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of more complex open source components for email formats.
-      status:
-      url:
-    - title: Find partners to work with and fund the development of open source templates for government-used content management systems such as Drupal, Wordpress, Sharepoint, and more designer prototyping templates.
-      status:
-      url:
-    - title: Create and implement modularized CSS and JS for each component so that they are easily used on a case by case basis.
-      status:
-      url:
+    - title: Change our name to more accurately describe what we are and what we do
+      status: In progress
+      url: https://github.com/18F/web-design-standards/issues/2300
+    - title: Develop an easier way to prototype and build consistently and incrementally
+      status: In progress
+      url: https://github.com/18F/web-design-standards/issues/2292
+    - title: A more flexible, consistent color system
+      status: In progress
+      url: https://github.com/18F/web-design-standards/issues/2296
+    - title: Clearer, more specific design and implementation guidance
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2293
+    - title: Better support and guidance for Federalist and Jekyll
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2294
+    - title: Better typographic flexibility and resilience, with or without webfonts
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2295
+    - title: A clearer connection between user research and patterns and components
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2297
+    - title: A clear, reliable way to stay up-to-date and track component changes and status
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2298
+    - title: A path to contribute components and research back to the system
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2299
+    - title: Grow our core government communities and our larger open source community
+      status: To-do
+      url: https://github.com/18F/web-design-standards/issues/2301

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -404,6 +404,10 @@ body {
   }
 }
 
+.product-roadmap-list {
+  max-width: 100% !important;
+}
+
 // Label links
 
 %label-maturity {
@@ -433,12 +437,13 @@ body {
   }
 }
 
-.label-alpha {
+.label-alpha,
+.label-in-progress {
   @include label-link($color-gold-lightest, $color-gold-lighter);
 }
 
 .label-beta,
-.label-in-progress {
+.label-to-do {
   @include label-link($color-primary-alt-lightest, $color-primary-alt-light);
 }
 

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -16,7 +16,7 @@ subnav:
 Below is our product roadmap: a long-term plan of the goals, features,
 and long-term direction of the U.S. Web Design Standards. We update this
 every few months with the status of our progress, as well as add new
-high-level future requests and ideas. You can also <a href="https://github.com/18F/web-design-standards/issues?q=is%3Aissue+is%3Aopen+label%3AEpic" class="">view our product roadmap goals on GitHub</a>.
+high-level future requests and ideas. You can also <a href="https://github.com/18F/web-design-standards/milestone/52" class="">view our product roadmap goals on GitHub</a>.
 
 {% for milestone in site.data.milestones %}
 <section>

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -13,26 +13,15 @@ subnav:
   text: title
 ---
 
-### Current work: our sprint milestones
-
-See what we’re working on now and in the future by viewing what is being
-worked on or queued up to work on in our sprint milestones below. These are
-two-week increments of work that we commit to finishing, using Agile Product
-Development practices.
-
-<a href="https://github.com/18F/web-design-standards/milestones" class="usa-button">View our sprint milestones</a>
-
-### Future work: our product roadmap
-
-Below is our our product roadmap: a long term plan of the goals, features,
+Below is our product roadmap: a long-term plan of the goals, features,
 and long-term direction of the U.S. Web Design Standards. We update this
 every few months with the status of our progress, as well as add new
-high-level future requests and ideas.
+high-level future requests and ideas. You can also <a href="https://github.com/18F/web-design-standards/issues?q=is%3Aissue+is%3Aopen+label%3AEpic" class="">view our product roadmap goals on GitHub</a>.
 
 {% for milestone in site.data.milestones %}
 <section>
   <h2 id="{{ milestone.id }}">{{ milestone.title }}</h2>
-  <ul>
+  <ul class="product-roadmap-list">
   {% for task in milestone.tasks %}
     <li id="tooltip-text-{{ task.title | slugify }}">
       {{ task.title }}


### PR DESCRIPTION
- Updates the product roadmap with our new roadmap items 
- Removes old milestones which were not relevant to the current work and muddled the page
- Adds in a `To-do` label for items not started yet, and swaps label color so `In progress` is yellow and `To-do` is blue.

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/update-roadmap/whats-new/product-roadmap/)

Closes https://github.com/18F/web-design-standards/issues/2205