### PR TITLE
Link roadmap list item text to GitHub issues 

### DIFF
--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -24,11 +24,13 @@ high-level future requests and ideas. You can also <a href="https://github.com/1
   <ul class="product-roadmap-list">
   {% for task in milestone.tasks %}
     <li id="tooltip-text-{{ task.title | slugify }}">
-      {{ task.title }}
+      <a href="{{ task.url }}" aria-describedby="tooltip-text-{{ task.title | slugify }}">
+        {{ task.title }}
+      </a>
       {% if task.status %}
-          <a class="usa-label label-{{ task.status | slugify }}" href="{{ task.url }}" aria-describedby="tooltip-text-{{ task.title | slugify }}">
-            {{ task.status }}
-          </a>
+        <span class="usa-label label-{{ task.status | slugify }}">
+          {{ task.status }}
+        </span>
       {% endif %}
     </li>
   {% endfor %}


### PR DESCRIPTION
## Description

Move the link to the roadmap list item text instead and off of the label.
This makes it more clear that you can click the individual roadmap item to see the details. 

[😎 Preview](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/sw-link-roadmap-items/whats-new/product-roadmap/)

## After screenshot
![screen shot 2018-01-17 at 11 34 52 am](https://user-images.githubusercontent.com/1449852/35054367-5877662e-fb7a-11e7-9e2b-2c77178e83cf.png)

## Before screenshot
![screen shot 2018-01-17 at 11 35 00 am](https://user-images.githubusercontent.com/1449852/35054370-5cf0c6a0-fb7a-11e7-8a01-35c234974465.png)

