### PR TITLE
Strip vestigial ARIA and remove pseudostyling from labels in roadmap

### DIFF
--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -909,10 +909,9 @@ h3 + .button_wrapper {
   background-color: $color-gray-warm-light;
 }
 
-// no such var
-//.usa-color-gray-cool-light {
-//  background-color: $color-gray-cool-light;
-//}
+.usa-color-gray-cool-light {
+  background-color: $color-gray-cool-light;
+}
 
 .usa-color-gold {
   background-color: $color-gold;

--- a/css/styleguide.scss
+++ b/css/styleguide.scss
@@ -418,38 +418,27 @@ body {
   position: absolute;
   text-decoration: none;
 
-  &:hover,
-  &:visited {
-    color: $color-gray-dark;
-  }
-
   &#{$external-href}::after {
     display: none;
   }
 }
 
-@mixin label-link($color-background, $color-background-hover) {
-  @extend %label-maturity;
-  background-color: $color-background;
-
-  &:hover {
-    background-color: $color-background-hover;
-  }
-}
-
 .label-alpha,
 .label-in-progress {
-  @include label-link($color-gold-lightest, $color-gold-lighter);
+  @extend %label-maturity;
+  background-color: $color-gold-lightest;
 }
 
 .label-beta,
 .label-to-do {
-  @include label-link($color-primary-alt-lightest, $color-primary-alt-light);
+  @extend %label-maturity;
+  background-color: $color-primary-alt-lightest;
 }
 
 .label-recommended,
 .label-done {
-  @include label-link($color-green-lightest, $color-green-lighter);
+  @extend %label-maturity;
+  background-color: $color-green-lightest;
 }
 
 h1 + .tooltip {
@@ -920,9 +909,10 @@ h3 + .button_wrapper {
   background-color: $color-gray-warm-light;
 }
 
-.usa-color-gray-cool-light {
-  background-color: $color-gray-cool-light;
-}
+// no such var
+//.usa-color-gray-cool-light {
+//  background-color: $color-gray-cool-light;
+//}
 
 .usa-color-gold {
   background-color: $color-gold;

--- a/pages/whats-new/product-roadmap.md
+++ b/pages/whats-new/product-roadmap.md
@@ -23,8 +23,8 @@ high-level future requests and ideas. You can also <a href="https://github.com/1
   <h2 id="{{ milestone.id }}">{{ milestone.title }}</h2>
   <ul class="product-roadmap-list">
   {% for task in milestone.tasks %}
-    <li id="tooltip-text-{{ task.title | slugify }}">
-      <a href="{{ task.url }}" aria-describedby="tooltip-text-{{ task.title | slugify }}">
+    <li>
+      <a href="{{ task.url }}">
         {{ task.title }}
       </a>
       {% if task.status %}


### PR DESCRIPTION
This removes unnecessary ARIA attributes from the roadmap list. It also removes hover states from labels, as there is no longer functionality that pseudostyling would support.

👀 [preview link](https://federalist-proxy.app.cloud.gov/preview/18f/web-design-standards-docs/dw-fix-roadmap-links/whats-new/product-roadmap/)

